### PR TITLE
Update gRPC endpoints for Collections and Identities

### DIFF
--- a/protos/gk/v1/gatekeeper.proto
+++ b/protos/gk/v1/gatekeeper.proto
@@ -66,11 +66,13 @@ message Collection {
 }
 
 message CreateCollectionRequest {
-	string name = 1;
+	optional string id   = 1;
+	string          name = 2;
 }
 
 message CreateIdentityRequest {
-	string sub = 1;
+	optional string id  = 1;
+	string          sub = 2;
 }
 
 message Identity {

--- a/src/datastore/collections.h
+++ b/src/datastore/collections.h
@@ -22,6 +22,8 @@ public:
 	Collection(const Data &data) noexcept;
 	Collection(Data &&data) noexcept;
 
+	Collection(const pg::row_t &t);
+
 	const std::string &id() const noexcept { return _data.id; }
 	const int         &rev() const noexcept { return _rev; }
 
@@ -39,4 +41,6 @@ private:
 };
 
 using Collections = std::vector<Collection>;
+
+Collection RetrieveCollection(const std::string &id);
 } // namespace datastore

--- a/src/datastore/collections_test.cpp
+++ b/src/datastore/collections_test.cpp
@@ -169,6 +169,37 @@ TEST_F(CollectionsTest, members) {
 	}
 }
 
+TEST_F(CollectionsTest, retrieve) {
+	// Success: retrieve data
+	{
+		std::string_view qry = R"(
+			insert into collections (
+				_id,
+				_rev,
+				name
+			) values (
+				$1::text,
+				$2::integer,
+				$3::text
+			);
+		)";
+
+		try {
+			datastore::pg::exec(
+				qry, "_id:CollectionsTest.retrieve", 2248, "name:CollectionsTest.retrieve");
+		} catch (const std::exception &e) {
+			FAIL() << e.what();
+		}
+
+		auto collection = datastore::RetrieveCollection("_id:CollectionsTest.retrieve");
+		EXPECT_EQ(2248, collection.rev());
+		EXPECT_EQ("name:CollectionsTest.retrieve", collection.name());
+	}
+
+	// Error: not found
+	{ EXPECT_THROW(datastore::RetrieveCollection("_id:dummy"), err::DatastoreCollectionNotFound); }
+}
+
 TEST_F(CollectionsTest, rev) {
 	// Success: revision increment
 	{

--- a/src/datastore/identities.h
+++ b/src/datastore/identities.h
@@ -18,6 +18,8 @@ public:
 	Identity(const Data &data) noexcept;
 	Identity(Data &&data) noexcept;
 
+	Identity(const pg::row_t &t);
+
 	const std::string &id() const noexcept { return _data.id; }
 	const int         &rev() const noexcept { return _rev; }
 

--- a/src/datastore/identities_test.cpp
+++ b/src/datastore/identities_test.cpp
@@ -42,6 +42,37 @@ TEST_F(IdentitiesTest, discard) {
 	EXPECT_EQ(0, count);
 }
 
+TEST_F(IdentitiesTest, retrieve) {
+	// Success: retrieve data
+	{
+		std::string_view qry = R"(
+			insert into identities (
+				_id,
+				_rev,
+				sub
+			) values (
+				$1::text,
+				$2::integer,
+				$3::text
+			);
+		)";
+
+		try {
+			datastore::pg::exec(
+				qry, "_id:IdentitiesTest.retrieve", 2308, "sub:IdentitiesTest.retrieve");
+		} catch (const std::exception &e) {
+			FAIL() << e.what();
+		}
+
+		auto identity = datastore::RetrieveIdentity("_id:IdentitiesTest.retrieve");
+		EXPECT_EQ(2308, identity.rev());
+		EXPECT_EQ("sub:IdentitiesTest.retrieve", identity.sub());
+	}
+
+	// Error: not found
+	{ EXPECT_THROW(datastore::RetrieveIdentity("_id:dummy"), err::DatastoreIdentityNotFound); }
+}
+
 TEST_F(IdentitiesTest, rev) {
 	// Success: revision increment
 	{

--- a/src/err/errors.h
+++ b/src/err/errors.h
@@ -7,6 +7,7 @@ using DatastoreRevisionMismatch = basic_error<"gk:1.1.1.409", "Revision mismatch
 
 using DatastoreDuplicateIdentity = basic_error<"gk:1.2.1.409", "Duplicate identity">;
 
+using DatastoreCollectionNotFound = basic_error<"gk:1.3.3.404", "Collection not found">;
 using DatastoreDuplicateCollectionMember =
 	basic_error<"gk:1.3.2.409", "Duplicate collection member">;
 using DatastoreInvalidCollectionOrMember =

--- a/src/err/errors.h
+++ b/src/err/errors.h
@@ -6,6 +6,7 @@ namespace err {
 using DatastoreRevisionMismatch = basic_error<"gk:1.1.1.409", "Revision mismatch">;
 
 using DatastoreDuplicateIdentity = basic_error<"gk:1.2.1.409", "Duplicate identity">;
+using DatastoreIdentityNotFound  = basic_error<"gk:1.2.2.404", "Identity not found">;
 
 using DatastoreCollectionNotFound = basic_error<"gk:1.3.3.404", "Collection not found">;
 using DatastoreDuplicateCollectionMember =

--- a/src/service/grpc.cpp
+++ b/src/service/grpc.cpp
@@ -10,6 +10,22 @@ grpc::ServerUnaryReactor *Grpc::CreateCollection(
 	gk::v1::Collection *response) {
 	auto *reactor = context->DefaultReactor();
 
+	if (request->has_id()) {
+		try {
+			auto col = datastore::RetrieveCollection(request->id());
+
+			reactor->Finish(
+				grpc::Status(grpc::StatusCode::ALREADY_EXISTS, "Duplicate collection id"));
+			return reactor;
+		} catch (const err::DatastoreCollectionNotFound &) {
+			// Collection with an `id` matching the request `id` doesn't exist, we can continue with
+			// creating a new one.
+		} catch (...) {
+			reactor->Finish(grpc::Status(grpc::StatusCode::UNAVAILABLE, "Failed to retrieve data"));
+			return reactor;
+		}
+	}
+
 	auto collection = map(request);
 	try {
 		collection.store();

--- a/src/service/grpc_test.cpp
+++ b/src/service/grpc_test.cpp
@@ -35,7 +35,7 @@ TEST_F(GrpcTest, CreateCollection) {
 		gk::v1::Collection                    response;
 
 		gk::v1::CreateCollectionRequest request;
-		request.set_name("sub:GrpcTest.CreateCollection");
+		request.set_name("name:GrpcTest.CreateCollection");
 
 		auto reactor = service.CreateCollection(&ctx, &request, &response);
 		EXPECT_TRUE(peer.test_status_set());

--- a/src/service/mappers.cpp
+++ b/src/service/mappers.cpp
@@ -3,12 +3,14 @@
 namespace service {
 datastore::Collection map(const gk::v1::CreateCollectionRequest *from) {
 	return {{
+		.id   = from->id(),
 		.name = from->name(),
 	}};
 }
 
 datastore::Identity map(const gk::v1::CreateIdentityRequest *from) {
 	return {{
+		.id  = from->id(),
 		.sub = from->sub(),
 	}};
 }


### PR DESCRIPTION
Update _Collections_ and _Identities_ endpoints to allow setting IDs during creation instead of only allowing autogenerated IDs.