### PR TITLE
Optimise build time

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,6 +11,7 @@ jobs:
   build:
     name: Build on ${{ matrix.os }} using ${{ matrix.compiler }}
     strategy:
+      fail-fast: false
       matrix:
         compiler:
           - g++

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,10 +19,6 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-        exclude:
-          # ubuntu-22.04 v20230507.1 seems to have issues with static linking
-          - os: ubuntu-latest
-            compiler: clang++
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,6 +19,10 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
+        exclude:
+          # ubuntu-22.04 v20230507.1 seems to have issues with static linking
+          - os: ubuntu-latest
+            compiler: clang++
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@ jobs:
   coverage:
     name: Code coverage
     runs-on: ubuntu-latest
+    container: ubuntu:23.04
     services:
       postgres:
         env:
@@ -20,27 +21,24 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - name: Setup lcov
+      - name: Install dependencies
         run: |
-          version="1.16"
-          mkdir ${{ runner.temp }}/lcov-src && cd $_
-          curl -Ls https://github.com/linux-test-project/lcov/releases/download/v${version}/lcov-${version}.tar.gz | tar -xz
-          cd lcov-${version}
-          sudo make install
+          apt update
+          apt install -y --no-install-recommends \
+            clang cmake libclang-rt-dev ninja-build \
+            libgrpc++-dev libprotobuf-dev protobuf-compiler-grpc \
+            libpq-dev postgresql-client \
+            lcov llvm
       - uses: actions/checkout@v3
       - name: Setup Postgres
         run: psql < datastore/schema.sql
         env:
           PGDATABASE: test-gatekeeper
-          PGHOST: localhost
+          PGHOST: postgres
           PGPASSWORD: gatekeeper
           PGUSER: gatekeeper
-      - uses: actions/cache@v3
-        with:
-          path: .build/_deps
-          key: ${{ runner.arch }}_${{ runner.os }}-${{ hashFiles('cmake/dependencies.cmake') }}
       - name: Configure CMake
-        run: cmake -B .build -DGATEKEEPER_ENABLE_COVERAGE=ON -DGATEKEEPER_ENABLE_TESTING=ON
+        run: cmake -B .build -G Ninja -DGATEKEEPER_ENABLE_COVERAGE=ON -DGATEKEEPER_ENABLE_TESTING=ON
       - name: Build
         run: cmake --build .build
       - name: Test
@@ -48,14 +46,21 @@ jobs:
         run: ctest
         env:
           PGDATABASE: test-gatekeeper
-          PGHOST: localhost
+          PGHOST: postgres
           PGPASSWORD: gatekeeper
           PGUSER: gatekeeper
       - name: Generate code coverage reports
         working-directory: ${{ github.workspace }}/.build
         run: |
-          lcov --capture --directory src --output-file coverage.out
-          lcov --extract coverage.out "${{ github.workspace }}/src/*" --output-file coverage.out
+          cat <<EOF > gcov.sh
+          #!/bin/sh
+          exec llvm-cov gcov "\$@"
+          EOF
+
+          chmod +x gcov.sh
+
+          lcov --capture --directory src --gcov-tool $(pwd)/gcov.sh --output-file coverage.out
+          lcov --extract coverage.out "${GITHUB_WORKSPACE}/src/*" --output-file coverage.out
           lcov --remove coverage.out "*_test*" --output-file coverage.out
           lcov --list coverage.out
       - name: Upload coverage to Codecov

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ set(BUILD_SHARED_LIBS OFF)
 
 option(GATEKEEPER_ENABLE_COVERAGE "Enable code coverage" OFF)
 option(GATEKEEPER_ENABLE_TESTING "Enable testing" OFF)
+option(GATEKEEPER_FAVOUR_SYSTEM_GRPC "Favour system installed gRPC over building from source" ON)
 
 include(cmake/dependencies.cmake)
 include(cmake/googleapis.cmake)

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -1,11 +1,12 @@
 include(FetchContent)
 
 # grpc & protobuf
-if(GATEKEEPER_FAVOUR_SYSTEM_GRPC)
+if (GATEKEEPER_FAVOUR_SYSTEM_GRPC)
+	find_package(Protobuf)
 	find_package(gRPC 1.48.0)
 endif()
 
-if(gRPC_FOUND)
+if (gRPC_FOUND)
 	message(STATUS "Using gRPC v${gRPC_VERSION}")
 
 	find_program(gRPC_CPP_PLUGIN_EXECUTABLE

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -2,13 +2,13 @@ include(FetchContent)
 
 # grpc & protobuf
 if (GATEKEEPER_FAVOUR_SYSTEM_GRPC)
-	find_package(Protobuf)
 	find_package(gRPC 1.48.0)
 endif()
 
 if (gRPC_FOUND)
 	message(STATUS "Using gRPC v${gRPC_VERSION}")
 
+	find_package(Protobuf REQUIRED)
 	find_program(gRPC_CPP_PLUGIN_EXECUTABLE
 		grpc_cpp_plugin
 		DOC "gRPC C++ plugin for protoc"

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -1,15 +1,42 @@
 include(FetchContent)
 
 # grpc & protobuf
-message(STATUS "Fetching gRPC and dependencies (this can take a while)")
-FetchContent_Declare(grpc
-	GIT_REPOSITORY https://github.com/grpc/grpc
-	GIT_TAG        v1.47.5
-)
-FetchContent_MakeAvailable(grpc)
-message(STATUS "Fetching gRPC and dependencies - done")
+if(GATEKEEPER_FAVOUR_SYSTEM_GRPC)
+	find_package(gRPC 1.48.0)
+endif()
 
-get_target_property(protobuf_include_dir protobuf::libprotoc INTERFACE_INCLUDE_DIRECTORIES)
+if(gRPC_FOUND)
+	message(STATUS "Using gRPC v${gRPC_VERSION}")
+
+	find_program(gRPC_CPP_PLUGIN_EXECUTABLE
+		grpc_cpp_plugin
+		DOC "gRPC C++ plugin for protoc"
+	)
+else()
+	message(STATUS "Fetching gRPC and dependencies (this can take a while)")
+	FetchContent_Declare(grpc
+		GIT_REPOSITORY https://github.com/grpc/grpc
+		GIT_TAG        v1.48.4
+	)
+
+	set(gRPC_BUILD_GRPC_CSHARP_PLUGIN OFF)
+	set(gRPC_BUILD_GRPC_NODE_PLUGIN OFF)
+	set(gRPC_BUILD_GRPC_OBJECTIVE_C_PLUGIN OFF)
+	set(gRPC_BUILD_GRPC_PHP_PLUGIN OFF)
+	set(gRPC_BUILD_GRPC_PYTHON_PLUGIN OFF)
+	set(gRPC_BUILD_GRPC_RUBY_PLUGIN OFF)
+
+	FetchContent_MakeAvailable(grpc)
+
+	# Ensure `FetchContent` outputs are aligned with `find_package` outputs
+	set(Protobuf_PROTOC_EXECUTABLE $<TARGET_FILE:protobuf::protoc>)
+	get_target_property(Protobuf_INCLUDE_DIR protobuf::libprotoc INTERFACE_INCLUDE_DIRECTORIES)
+
+	add_library(gRPC::grpc++ ALIAS grpc++)
+	set(gRPC_CPP_PLUGIN_EXECUTABLE $<TARGET_FILE:grpc_cpp_plugin>)
+
+	message(STATUS "Fetching gRPC and dependencies - done")
+endif()
 
 # googleapis
 FetchContent_Declare(googleapis

--- a/cmake/googleapis.cmake
+++ b/cmake/googleapis.cmake
@@ -25,10 +25,10 @@ set(googleapis_sources
 add_custom_command(
 	OUTPUT ${googleapis_headers} ${googleapis_sources}
 	DEPENDS ${googleapis_protos}
-	COMMAND $<TARGET_FILE:protoc>
+	COMMAND ${Protobuf_PROTOC_EXECUTABLE}
 	ARGS
 		--proto_path=${googleapis_SOURCE_DIR}
-		--proto_path=${protobuf_include_dir}
+		--proto_path=${Protobuf_INCLUDE_DIR}
 		--cpp_out=${CMAKE_CURRENT_BINARY_DIR}
 		${googleapis_protos}
 )
@@ -39,6 +39,6 @@ add_library(googleapis
 
 target_include_directories(googleapis
 	PUBLIC ${CMAKE_CURRENT_BINARY_DIR}
-	PRIVATE ${protobuf_include_dir}
+	PRIVATE ${Protobuf_INCLUDE_DIR}
 )
 

--- a/proto/CMakeLists.txt
+++ b/proto/CMakeLists.txt
@@ -22,14 +22,14 @@ set(sources
 add_custom_command(
 	OUTPUT ${headers} ${sources}
 	DEPENDS ${protos}
-	COMMAND $<TARGET_FILE:protoc>
+	COMMAND ${Protobuf_PROTOC_EXECUTABLE}
 	ARGS
 		--proto_path=${CMAKE_CURRENT_SOURCE_DIR}
 		--proto_path=${googleapis_SOURCE_DIR}
-		--proto_path=${protobuf_include_dir}
+		--proto_path=${Protobuf_INCLUDE_DIR}
 		--cpp_out=${CMAKE_CURRENT_BINARY_DIR}
 		--grpc_out=${CMAKE_CURRENT_BINARY_DIR}
-		--plugin=protoc-gen-grpc=$<TARGET_FILE:grpc_cpp_plugin>
+		--plugin=protoc-gen-grpc=${gRPC_CPP_PLUGIN_EXECUTABLE}
 		${protos}
 )
 
@@ -43,7 +43,7 @@ target_include_directories(proto
 
 target_link_libraries(proto
 	googleapis
-	grpc++
+	gRPC::grpc++
 )
 
 add_library(${PROJECT_NAME}::libproto ALIAS proto)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,7 +49,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
 	LINK_SEARCH_END_STATIC ON
 )
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+if (NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
 	target_link_libraries(${PROJECT_NAME} PRIVATE -static-libgcc -static-libstdc++)
 endif()
 


### PR DESCRIPTION
Building gRPC from source (via FetchContent) extends the overall build time significantly. This change allow using system installed gRPC if available to reduce the build time. 