### PR TITLE
Source based code coverage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
         run: |
           apt update
           apt install -y --no-install-recommends \
-            clang cmake libclang-rt-dev ninja-build \
+            clang cmake libclang-rt-dev make ninja-build \
             libgrpc++-dev libprotobuf-dev protobuf-compiler-grpc \
             libpq-dev postgresql-client \
             lcov llvm
@@ -37,32 +37,15 @@ jobs:
           PGHOST: postgres
           PGPASSWORD: gatekeeper
           PGUSER: gatekeeper
-      - name: Configure CMake
-        run: cmake -B .build -G Ninja -DGATEKEEPER_ENABLE_COVERAGE=ON -DGATEKEEPER_ENABLE_TESTING=ON
       - name: Build
-        run: cmake --build .build
-      - name: Test
-        working-directory: ${{ github.workspace }}/.build
-        run: ctest
+        run: make
+      - name: Generate code coverage reports
+        run: make coverage:lcov
         env:
           PGDATABASE: test-gatekeeper
           PGHOST: postgres
           PGPASSWORD: gatekeeper
           PGUSER: gatekeeper
-      - name: Generate code coverage reports
-        working-directory: ${{ github.workspace }}/.build
-        run: |
-          cat <<EOF > gcov.sh
-          #!/bin/sh
-          exec llvm-cov gcov "\$@"
-          EOF
-
-          chmod +x gcov.sh
-
-          lcov --capture --directory src --gcov-tool $(pwd)/gcov.sh --output-file coverage.out
-          lcov --extract coverage.out "${GITHUB_WORKSPACE}/src/*" --output-file coverage.out
-          lcov --remove coverage.out "*_test*" --output-file coverage.out
-          lcov --list coverage.out
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,15 @@ option(GATEKEEPER_ENABLE_COVERAGE "Enable code coverage" OFF)
 option(GATEKEEPER_ENABLE_TESTING "Enable testing" OFF)
 option(GATEKEEPER_FAVOUR_SYSTEM_GRPC "Favour system installed gRPC over building from source" ON)
 
+if (GATEKEEPER_ENABLE_COVERAGE)
+	if (NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+		message(FATAL_ERROR
+			"Code coverage is only available with clang. "
+			"Can't continue with GATEKEEPER_ENABLE_COVERAGE=ON."
+		)
+	endif()
+endif()
+
 include(cmake/dependencies.cmake)
 include(cmake/googleapis.cmake)
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
-BUILDDIR = .build
-BINDIR   = $(BUILDDIR)/bin
-BINARY   = $(BINDIR)/gatekeeper
+BUILDDIR  = .build
+BINDIR    = $(BUILDDIR)/bin
+BINARY    = $(BINDIR)/gatekeeper
+BUILDFILE = $(BUILDDIR)/build.ninja
 
 PROTODIR  = proto
 SOURCEDIR = src
@@ -24,15 +25,15 @@ ifeq (, $(llvm-profdata))
 endif
 
 
-.PHONY: clean
+.PHONY: $(BINARY) all clean coverage coverage\:lcov lint lint\:ci lint\:fix run test
 .SILENT: coverage lint
 
 all: $(BINARY)
 
-$(BINARY): $(BUILDDIR)
+$(BINARY): $(BUILDFILE)
 	cmake --build $(BUILDDIR)
 
-$(BUILDDIR):
+$(BUILDFILE):
 	cmake -B $(BUILDDIR) -G Ninja -DGATEKEEPER_ENABLE_COVERAGE=ON -DGATEKEEPER_ENABLE_TESTING=ON
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 BUILDDIR = .build
-BINARY   = $(BUILDDIR)/bin/gatekeeper
+BINDIR   = $(BUILDDIR)/bin
+BINARY   = $(BINDIR)/gatekeeper
 
 PROTODIR  = proto
 SOURCEDIR = src
@@ -7,14 +8,28 @@ SOURCEDIR = src
 SOURCES  := $(shell find $(PROTODIR) -type f -name '*.proto')
 SOURCES  += $(shell find $(SOURCEDIR) -type f -name '*.h' -o -name '*.cpp')
 
+LCOV_OUTPUT       = $(BUILDDIR)/coverage.out
+PROFDATA_OUTPUT   = $(BUILDDIR)/coverage.profdata
+TESTING_BINARIES := $(shell find $(BINDIR) -type f -executable -name "*_tests")
 
-.PHONY: $(BINARY) clean
-.SILENT: lint
+llvm-cov      = $(shell which llvm-cov)
+llvm-profdata = $(shell which llvm-profdata)
+
+ifeq (, $(llvm-cov))
+	llvm-cov = $(shell xcrun --find llvm-cov)
+endif
+
+ifeq (, $(llvm-profdata))
+	llvm-profdata = $(shell xcrun --find llvm-profdata)
+endif
+
+
+.PHONY: clean
+.SILENT: coverage lint
 
 all: $(BINARY)
 
 $(BINARY): $(BUILDDIR)
-	find $(BUILDDIR)/$(SOURCEDIR) -name "*.gcda" -exec rm {} +
 	cmake --build $(BUILDDIR)
 
 $(BUILDDIR):
@@ -22,6 +37,21 @@ $(BUILDDIR):
 
 clean:
 	cmake --build $(BUILDDIR) --target clean
+
+coverage: $(BINARY)
+	find $(BUILDDIR)/$(SOURCEDIR) -type f -name "*.profraw" -exec rm {} +
+	LLVM_PROFILE_FILE="%p.profraw" ctest --test-dir $(BUILDDIR)
+
+	echo '' # Empty line to separate outputs
+	-rm $(PROFDATA_OUTPUT)
+	find $(BUILDDIR)/$(SOURCEDIR) -type f -name "*.profraw" -exec $(llvm-profdata) merge --sparse=true --output=$(PROFDATA_OUTPUT) {} +
+	$(llvm-cov) report -ignore-filename-regex='$(BUILDDIR)\/' -instr-profile=$(PROFDATA_OUTPUT) $(foreach bin, $(TESTING_BINARIES), -object=$(bin))
+
+coverage\:lcov: coverage
+	$(llvm-cov) export -format=lcov -ignore-filename-regex='$(BUILDDIR)\/' -ignore-filename-regex='.*_test\.cpp' -instr-profile=$(PROFDATA_OUTPUT) $(foreach bin, $(TESTING_BINARIES), -object=$(bin)) > $(LCOV_OUTPUT)
+
+	@echo '' # Empty line to separate outputs
+	lcov --list $(LCOV_OUTPUT)
 
 lint:
 ifeq (, $(shell which clang-format))
@@ -40,5 +70,5 @@ run: $(BINARY)
 	$(BINARY)
 
 test: $(BINARY)
-	ctest --test-dir .build --output-on-failure
+	ctest --test-dir $(BUILDDIR) --output-on-failure
 

--- a/src/datastore/CMakeLists.txt
+++ b/src/datastore/CMakeLists.txt
@@ -16,11 +16,11 @@ target_link_libraries(datastore
 
 if (GATEKEEPER_ENABLE_COVERAGE)
 	target_compile_options(datastore
-		PRIVATE --coverage
+		PRIVATE -fprofile-instr-generate -fcoverage-mapping
 	)
 
 	target_link_options(datastore
-		INTERFACE -fprofile-arcs
+		INTERFACE -fprofile-instr-generate
 	)
 endif()
 
@@ -39,11 +39,11 @@ if (GATEKEEPER_ENABLE_TESTING)
 
 	if (GATEKEEPER_ENABLE_COVERAGE)
 		target_compile_options(datastore_tests
-			PRIVATE --coverage
+			PRIVATE -fprofile-instr-generate -fcoverage-mapping
 		)
 
 		target_link_options(datastore_tests
-			PRIVATE -fprofile-arcs
+			PRIVATE -fprofile-instr-generate
 		)
 	endif()
 

--- a/src/err/CMakeLists.txt
+++ b/src/err/CMakeLists.txt
@@ -20,11 +20,11 @@ if (GATEKEEPER_ENABLE_TESTING)
 
 	if (GATEKEEPER_ENABLE_COVERAGE)
 		target_compile_options(err_tests
-			PRIVATE --coverage
+			PRIVATE -fprofile-instr-generate -fcoverage-mapping
 		)
 
 		target_link_options(err_tests
-			PRIVATE -fprofile-arcs
+			PRIVATE -fprofile-instr-generate
 		)
 	endif()
 

--- a/src/service/CMakeLists.txt
+++ b/src/service/CMakeLists.txt
@@ -12,11 +12,11 @@ target_link_libraries(service
 
 if (GATEKEEPER_ENABLE_COVERAGE)
 	target_compile_options(service
-		PRIVATE --coverage
+		PRIVATE -fprofile-instr-generate -fcoverage-mapping
 	)
 
 	target_link_options(service
-		INTERFACE -fprofile-arcs
+		INTERFACE -fprofile-instr-generate
 	)
 endif()
 
@@ -35,11 +35,11 @@ if (GATEKEEPER_ENABLE_TESTING)
 
 	if (GATEKEEPER_ENABLE_COVERAGE)
 		target_compile_options(service_tests
-			PRIVATE --coverage
+			PRIVATE -fprofile-instr-generate -fcoverage-mapping
 		)
 
 		target_link_options(service_tests
-			PRIVATE -fprofile-arcs
+			PRIVATE -fprofile-instr-generate
 		)
 	endif()
 


### PR DESCRIPTION
Use clang's source-based code coverage (`llvm-cov`) instead of `gcov`. 