### PR TITLE
Change names of junction tables

### DIFF
--- a/datastore/schema.sql
+++ b/datastore/schema.sql
@@ -45,15 +45,28 @@ create table if not exists roles (
 	constraint "roles.pkey" primary key (_id)
 );
 
-create table if not exists "collections_access-policies" (
+create table if not exists "access-policies_collections" (
 	collection_id text not null,
 	policy_id     text not null,
 
-	constraint "collections_access-policies.pkey" primary key (collection_id, policy_id),
-	constraint "collections_access-policies.fkey-collection_id" foreign key (collection_id)
+	constraint "access-policies_collections.pkey" primary key (collection_id, policy_id),
+	constraint "access-policies_collections.fkey-collection_id" foreign key (collection_id)
 		references collections(_id)
 		on delete cascade,
-	constraint "collections_access-policies.fkey-policy_id" foreign key (policy_id)
+	constraint "access-policies_collections.fkey-policy_id" foreign key (policy_id)
+		references "access-policies"(_id)
+		on delete cascade
+);
+
+create table if not exists "access-policies_identities" (
+	identity_id text not null,
+	policy_id   text not null,
+
+	constraint "access-policies_identities.pkey" primary key (identity_id, policy_id),
+	constraint "access-policies_identities.fkey-identity_id" foreign key (identity_id)
+		references identities(_id)
+		on delete cascade,
+	constraint "access-policies_identities.fkey-policy_id" foreign key (policy_id)
 		references "access-policies"(_id)
 		on delete cascade
 );
@@ -71,41 +84,29 @@ create table if not exists "collections_identities" (
 		on delete cascade
 );
 
-create table if not exists "collections_rbac-policies" (
+create table if not exists "rbac-policies_collections" (
 	collection_id text not null,
 	policy_id     text not null,
 
-	constraint "collections_rbac-policies.pkey" primary key (collection_id, policy_id),
-	constraint "collections_rbac-policies.fkey-collection_id" foreign key (collection_id)
+	constraint "rbac-policies_collections.pkey" primary key (collection_id, policy_id),
+	constraint "rbac-policies_collections.fkey-collection_id" foreign key (collection_id)
 		references collections(_id)
 		on delete cascade,
-	constraint "collections_rbac-policies.fkey-policy_id" foreign key (policy_id)
+	constraint "rbac-policies_collections.fkey-policy_id" foreign key (policy_id)
 		references "rbac-policies"(_id)
 		on delete cascade
 );
 
-create table if not exists "identities_access-policies" (
+
+create table if not exists "rbac-policies_identities" (
 	identity_id text not null,
 	policy_id   text not null,
 
-	constraint "identities_access-policies.pkey" primary key (identity_id, policy_id),
-	constraint "identities_access-policies.fkey-identity_id" foreign key (identity_id)
+	constraint "rbac-policies_identities.pkey" primary key (identity_id, policy_id),
+	constraint "rbac-policies_identities.fkey-identity_id" foreign key (identity_id)
 		references identities(_id)
 		on delete cascade,
-	constraint "identities_access-policies.fkey-policy_id" foreign key (policy_id)
-		references "access-policies"(_id)
-		on delete cascade
-);
-
-create table if not exists "identities_rbac-policies" (
-	identity_id text not null,
-	policy_id   text not null,
-
-	constraint "identities_rbac-policies.pkey" primary key (identity_id, policy_id),
-	constraint "identities_rbac-policies.fkey-identity_id" foreign key (identity_id)
-		references identities(_id)
-		on delete cascade,
-	constraint "identities_rbac-policies.fkey-policy_id" foreign key (policy_id)
+	constraint "rbac-policies_identities.fkey-policy_id" foreign key (policy_id)
 		references "rbac-policies"(_id)
 		on delete cascade
 );

--- a/datastore/schema.sql
+++ b/datastore/schema.sql
@@ -45,29 +45,30 @@ create table if not exists roles (
 	constraint "roles.pkey" primary key (_id)
 );
 
-create table if not exists "access-policies_collections" (
-	collection_id text not null,
-	policy_id     text not null,
 
-	constraint "access-policies_collections.pkey" primary key (collection_id, policy_id),
-	constraint "access-policies_collections.fkey-collection_id" foreign key (collection_id)
-		references collections(_id)
-		on delete cascade,
+create table if not exists "access-policies_collections" (
+	policy_id     text not null,
+	collection_id text not null,
+
+	constraint "access-policies_collections.pkey" primary key (policy_id, collection_id),
 	constraint "access-policies_collections.fkey-policy_id" foreign key (policy_id)
 		references "access-policies"(_id)
+		on delete cascade,
+	constraint "access-policies_collections.fkey-collection_id" foreign key (collection_id)
+		references collections(_id)
 		on delete cascade
 );
 
 create table if not exists "access-policies_identities" (
-	identity_id text not null,
 	policy_id   text not null,
+	identity_id text not null,
 
-	constraint "access-policies_identities.pkey" primary key (identity_id, policy_id),
-	constraint "access-policies_identities.fkey-identity_id" foreign key (identity_id)
-		references identities(_id)
-		on delete cascade,
+	constraint "access-policies_identities.pkey" primary key (policy_id, identity_id),
 	constraint "access-policies_identities.fkey-policy_id" foreign key (policy_id)
 		references "access-policies"(_id)
+		on delete cascade,
+	constraint "access-policies_identities.fkey-identity_id" foreign key (identity_id)
+		references identities(_id)
 		on delete cascade
 );
 
@@ -85,29 +86,28 @@ create table if not exists "collections_identities" (
 );
 
 create table if not exists "rbac-policies_collections" (
-	collection_id text not null,
 	policy_id     text not null,
+	collection_id text not null,
 
-	constraint "rbac-policies_collections.pkey" primary key (collection_id, policy_id),
-	constraint "rbac-policies_collections.fkey-collection_id" foreign key (collection_id)
-		references collections(_id)
-		on delete cascade,
+	constraint "rbac-policies_collections.pkey" primary key (policy_id, collection_id),
 	constraint "rbac-policies_collections.fkey-policy_id" foreign key (policy_id)
 		references "rbac-policies"(_id)
+		on delete cascade,
+	constraint "rbac-policies_collections.fkey-collection_id" foreign key (collection_id)
+		references collections(_id)
 		on delete cascade
 );
 
-
 create table if not exists "rbac-policies_identities" (
-	identity_id text not null,
 	policy_id   text not null,
+	identity_id text not null,
 
-	constraint "rbac-policies_identities.pkey" primary key (identity_id, policy_id),
-	constraint "rbac-policies_identities.fkey-identity_id" foreign key (identity_id)
-		references identities(_id)
-		on delete cascade,
+	constraint "rbac-policies_identities.pkey" primary key (policy_id, identity_id),
 	constraint "rbac-policies_identities.fkey-policy_id" foreign key (policy_id)
 		references "rbac-policies"(_id)
+		on delete cascade,
+	constraint "rbac-policies_identities.fkey-identity_id" foreign key (identity_id)
+		references identities(_id)
 		on delete cascade
 );
 


### PR DESCRIPTION
This issue changes the names of junction tables by swapping the referred tables and prefixing the names with the policy tables (e.g. `identities_rbac-policies` becomes `rbac-policies_identities`)