### PR TITLE
Collection Members endpoints

### DIFF
--- a/src/service/grpc.cpp
+++ b/src/service/grpc.cpp
@@ -116,6 +116,27 @@ grpc::ServerUnaryReactor *Grpc::AddCollectionMember(
 	return reactor;
 };
 
+grpc::ServerUnaryReactor *Grpc::ListCollectionMembers(
+	grpc::CallbackServerContext *context, const gk::v1::ListCollectionMembersRequest *request,
+	gk::v1::ListCollectionMembersResponse *response) {
+	auto *reactor = context->DefaultReactor();
+
+	// TODO: error handling
+	// TODO: pagination and response metadata
+	auto collection = datastore::RetrieveCollection(request->id());
+	auto memberIds  = collection.members();
+
+	for (const auto &id : memberIds) {
+		auto identity   = datastore::RetrieveIdentity(id);
+		auto pbIdentity = response->add_data();
+
+		map(identity, pbIdentity);
+	}
+
+	reactor->Finish(grpc::Status::OK);
+	return reactor;
+}
+
 grpc::ServerUnaryReactor *Grpc::RemoveCollectionMember(
 	grpc::CallbackServerContext *context, const gk::v1::RemoveCollectionMemberRequest *request,
 	gk::v1::RemoveCollectionMemberResponse *response) {

--- a/src/service/grpc.cpp
+++ b/src/service/grpc.cpp
@@ -116,6 +116,19 @@ grpc::ServerUnaryReactor *Grpc::AddCollectionMember(
 	return reactor;
 };
 
+grpc::ServerUnaryReactor *Grpc::RemoveCollectionMember(
+	grpc::CallbackServerContext *context, const gk::v1::RemoveCollectionMemberRequest *request,
+	gk::v1::RemoveCollectionMemberResponse *response) {
+	auto *reactor = context->DefaultReactor();
+
+	// TODO: error handling
+	auto collection = datastore::RetrieveCollection(request->collection_id());
+	collection.remove(request->identity_id());
+
+	reactor->Finish(grpc::Status::OK);
+	return reactor;
+}
+
 // Identities
 grpc::ServerUnaryReactor *Grpc::CreateIdentity(
 	grpc::CallbackServerContext *context, const gk::v1::CreateIdentityRequest *request,

--- a/src/service/grpc.cpp
+++ b/src/service/grpc.cpp
@@ -102,6 +102,20 @@ grpc::ServerUnaryReactor *Grpc::UpdateCollection(
 	return reactor;
 }
 
+// Collections - members
+grpc::ServerUnaryReactor *Grpc::AddCollectionMember(
+	grpc::CallbackServerContext *context, const gk::v1::AddCollectionMemberRequest *request,
+	gk::v1::AddCollectionMemberResponse *response) {
+	auto *reactor = context->DefaultReactor();
+
+	// TODO: error handling
+	auto collection = datastore::RetrieveCollection(request->collection_id());
+	collection.add(request->identity_id());
+
+	reactor->Finish(grpc::Status::OK);
+	return reactor;
+};
+
 // Identities
 grpc::ServerUnaryReactor *Grpc::CreateIdentity(
 	grpc::CallbackServerContext *context, const gk::v1::CreateIdentityRequest *request,

--- a/src/service/grpc.h
+++ b/src/service/grpc.h
@@ -23,6 +23,10 @@ public:
 		grpc::CallbackServerContext *context, const gk::v1::AddCollectionMemberRequest *request,
 		gk::v1::AddCollectionMemberResponse *response) override;
 
+	grpc::ServerUnaryReactor *RemoveCollectionMember(
+		grpc::CallbackServerContext *context, const gk::v1::RemoveCollectionMemberRequest *request,
+		gk::v1::RemoveCollectionMemberResponse *response) override;
+
 	// Identities
 	grpc::ServerUnaryReactor *CreateIdentity(
 		grpc::CallbackServerContext *context, const gk::v1::CreateIdentityRequest *request,

--- a/src/service/grpc.h
+++ b/src/service/grpc.h
@@ -18,6 +18,11 @@ public:
 		grpc::CallbackServerContext *context, const gk::v1::UpdateCollectionRequest *request,
 		gk::v1::Collection *response) override;
 
+	// Collections - members
+	grpc::ServerUnaryReactor *AddCollectionMember(
+		grpc::CallbackServerContext *context, const gk::v1::AddCollectionMemberRequest *request,
+		gk::v1::AddCollectionMemberResponse *response) override;
+
 	// Identities
 	grpc::ServerUnaryReactor *CreateIdentity(
 		grpc::CallbackServerContext *context, const gk::v1::CreateIdentityRequest *request,

--- a/src/service/grpc.h
+++ b/src/service/grpc.h
@@ -23,6 +23,10 @@ public:
 		grpc::CallbackServerContext *context, const gk::v1::AddCollectionMemberRequest *request,
 		gk::v1::AddCollectionMemberResponse *response) override;
 
+	grpc::ServerUnaryReactor *ListCollectionMembers(
+		grpc::CallbackServerContext *context, const gk::v1::ListCollectionMembersRequest *request,
+		gk::v1::ListCollectionMembersResponse *response) override;
+
 	grpc::ServerUnaryReactor *RemoveCollectionMember(
 		grpc::CallbackServerContext *context, const gk::v1::RemoveCollectionMemberRequest *request,
 		gk::v1::RemoveCollectionMemberResponse *response) override;

--- a/src/service/grpc_test.cpp
+++ b/src/service/grpc_test.cpp
@@ -187,6 +187,33 @@ TEST_F(GrpcTest, UpdateCollection) {
 	}
 }
 
+// Collections - members
+TEST_F(GrpcTest, AddCollectionMember) {
+	datastore::Collection collection({.name = "name:GrpcTest.AddCollectionMember"});
+	ASSERT_NO_THROW(collection.store());
+
+	service::Grpc service;
+
+	// Success: add collection member
+	{
+		datastore::Identity identity({.sub="sub:GrpcTest.AddCollectionMember"});
+		ASSERT_NO_THROW(identity.store());
+
+		grpc::CallbackServerContext           ctx;
+		grpc::testing::DefaultReactorTestPeer peer(&ctx);
+		gk::v1::AddCollectionMemberResponse   response;
+
+		gk::v1::AddCollectionMemberRequest request;
+		request.set_collection_id(collection.id());
+		request.set_identity_id(identity.id());
+
+		auto reactor = service.AddCollectionMember(&ctx, &request, &response);
+		EXPECT_TRUE(peer.test_status_set());
+		EXPECT_TRUE(peer.test_status().ok());
+		EXPECT_EQ(peer.reactor(), reactor);
+	}
+}
+
 // Identities
 TEST_F(GrpcTest, CreateIdentity) {
 	service::Grpc service;

--- a/src/service/grpc_test.cpp
+++ b/src/service/grpc_test.cpp
@@ -196,7 +196,7 @@ TEST_F(GrpcTest, AddCollectionMember) {
 
 	// Success: add collection member
 	{
-		datastore::Identity identity({.sub="sub:GrpcTest.AddCollectionMember"});
+		datastore::Identity identity({.sub = "sub:GrpcTest.AddCollectionMember"});
 		ASSERT_NO_THROW(identity.store());
 
 		grpc::CallbackServerContext           ctx;
@@ -208,6 +208,33 @@ TEST_F(GrpcTest, AddCollectionMember) {
 		request.set_identity_id(identity.id());
 
 		auto reactor = service.AddCollectionMember(&ctx, &request, &response);
+		EXPECT_TRUE(peer.test_status_set());
+		EXPECT_TRUE(peer.test_status().ok());
+		EXPECT_EQ(peer.reactor(), reactor);
+	}
+}
+
+TEST_F(GrpcTest, RemoveCollectionMember) {
+	datastore::Collection collection({.name = "name:GrpcTest.RemoveCollectionMember"});
+	ASSERT_NO_THROW(collection.store());
+
+	service::Grpc service;
+
+	// Success: remove collection member
+	{
+		datastore::Identity identity({.sub = "sub:GrpcTest.RemoveCollectionMember"});
+		ASSERT_NO_THROW(identity.store());
+		ASSERT_NO_THROW(collection.add(identity.id()));
+
+		grpc::CallbackServerContext            ctx;
+		grpc::testing::DefaultReactorTestPeer  peer(&ctx);
+		gk::v1::RemoveCollectionMemberResponse response;
+
+		gk::v1::RemoveCollectionMemberRequest request;
+		request.set_collection_id(collection.id());
+		request.set_identity_id(identity.id());
+
+		auto reactor = service.RemoveCollectionMember(&ctx, &request, &response);
 		EXPECT_TRUE(peer.test_status_set());
 		EXPECT_TRUE(peer.test_status().ok());
 		EXPECT_EQ(peer.reactor(), reactor);

--- a/src/service/grpc_test.cpp
+++ b/src/service/grpc_test.cpp
@@ -214,6 +214,44 @@ TEST_F(GrpcTest, AddCollectionMember) {
 	}
 }
 
+TEST_F(GrpcTest, ListCollectionMembers) {
+	datastore::Collection collection({.name = "name:GrpcTest.ListCollectionMembers"});
+	ASSERT_NO_THROW(collection.store());
+
+	service::Grpc service;
+
+	// Success: list collection members
+	{
+		std::array<datastore::Identity, 2> identities = {
+			datastore::Identity({.sub = "sub:GrpcTest.ListCollectionMembers-1"}),
+			datastore::Identity({.sub = "sub:GrpcTest.ListCollectionMembers-2"}),
+		};
+
+		for (const auto &idn : identities) {
+			ASSERT_NO_THROW(idn.store());
+		}
+
+		ASSERT_NO_THROW(collection.add(identities[0].id()));
+
+		grpc::CallbackServerContext           ctx;
+		grpc::testing::DefaultReactorTestPeer peer(&ctx);
+		gk::v1::ListCollectionMembersResponse response;
+
+		gk::v1::ListCollectionMembersRequest request;
+		request.set_id(collection.id());
+
+		auto reactor = service.ListCollectionMembers(&ctx, &request, &response);
+		EXPECT_TRUE(peer.test_status_set());
+		EXPECT_TRUE(peer.test_status().ok());
+		EXPECT_EQ(peer.reactor(), reactor);
+
+		EXPECT_FALSE(response.has_meta());
+
+		ASSERT_EQ(1, response.data_size());
+		EXPECT_EQ(identities[0].id(), response.data(0).id());
+	}
+}
+
 TEST_F(GrpcTest, RemoveCollectionMember) {
 	datastore::Collection collection({.name = "name:GrpcTest.RemoveCollectionMember"});
 	ASSERT_NO_THROW(collection.store());

--- a/src/service/grpc_test.cpp
+++ b/src/service/grpc_test.cpp
@@ -211,6 +211,22 @@ TEST_F(GrpcTest, AddCollectionMember) {
 		EXPECT_TRUE(peer.test_status_set());
 		EXPECT_TRUE(peer.test_status().ok());
 		EXPECT_EQ(peer.reactor(), reactor);
+
+		{
+			std::string_view qry = R"(
+					select count(*)
+					from collections_identities
+					where
+						collection_id = $1::text
+						and identity_id = $2::text;
+				)";
+
+			auto res = datastore::pg::exec(qry, collection.id(), identity.id());
+			ASSERT_EQ(1, res.size());
+
+			auto [count] = res[0].as<int>();
+			EXPECT_EQ(1, count);
+		}
 	}
 }
 
@@ -276,6 +292,22 @@ TEST_F(GrpcTest, RemoveCollectionMember) {
 		EXPECT_TRUE(peer.test_status_set());
 		EXPECT_TRUE(peer.test_status().ok());
 		EXPECT_EQ(peer.reactor(), reactor);
+
+		{
+			std::string_view qry = R"(
+					select count(*)
+					from collections_identities
+					where
+						collection_id = $1::text
+						and identity_id = $2::text;
+				)";
+
+			auto res = datastore::pg::exec(qry, collection.id(), identity.id());
+			ASSERT_EQ(1, res.size());
+
+			auto [count] = res[0].as<int>();
+			EXPECT_EQ(0, count);
+		}
 	}
 }
 


### PR DESCRIPTION
gRPC endpoints to add, list and remove collection members.

⚠️ This PR is missing error handling and pagination for listing members which are expected to be implemented separately.