### PR TITLE
Update protos

### DIFF
--- a/proto/gk/v1/gatekeeper.proto
+++ b/proto/gk/v1/gatekeeper.proto
@@ -189,8 +189,12 @@ message AccessPolicyRule {
 }
 
 message CheckAccessRequest {
-	string identity_id = 1;
-	string resource    = 2;
+	oneof identity {
+		string identity_id  = 1;
+		string identity_sub = 2;
+	}
+
+	string resource = 3;
 }
 
 message CheckAccessResponse {
@@ -310,8 +314,12 @@ message RbacPolicyRule {
 }
 
 message CheckRbacRequest {
-	string identity_id = 1;
-	string permission  = 2;
+	oneof identity {
+		string identity_id  = 1;
+		string identity_sub = 2;
+	}
+
+	string permission = 3;
 }
 
 message CheckRbacResponse {

--- a/src/service/grpc.cpp
+++ b/src/service/grpc.cpp
@@ -11,6 +11,12 @@ grpc::ServerUnaryReactor *Grpc::CheckAccess(
 	gk::v1::CheckAccessResponse *response) {
 	auto *reactor = context->DefaultReactor();
 
+	if (request->has_identity_sub()) {
+		// TODO: implement checking access by sub
+		reactor->Finish(grpc::Status(grpc::StatusCode::UNIMPLEMENTED, "Not implemented"));
+		return reactor;
+	}
+
 	try {
 		const auto access =
 			datastore::AccessPolicy::Record(request->identity_id(), request->resource());


### PR DESCRIPTION
Update protos to allow checking Access and RBAC either using identity `id` or `sub`.