### PR TITLE
Rebuild cache

### DIFF
--- a/datastore/schema.sql
+++ b/datastore/schema.sql
@@ -33,10 +33,10 @@ create table if not exists identities (
 create table if not exists "rbac-policies" (
 	_id   text    not null,
 	_rev  integer not null,
-	name  text    not null,
-	rules jsonb,
+	name  text,
 
-	constraint "rbac-policies.pkey" primary key (_id)
+	constraint "rbac-policies.pkey" primary key (_id),
+	constraint "rbac-policies.check-name" check (name <> '')
 );
 
 create table if not exists roles (
@@ -116,8 +116,9 @@ create table if not exists "rbac-policies_identities" (
 );
 
 create table if not exists "rbac-policies_roles" (
-	policy_id text not null,
-	role_id   text not null,
+	policy_id text  not null,
+	role_id   text  not null,
+	attrs     jsonb,
 
 	constraint "rbac-policies_roles.pkey" primary key (policy_id, role_id),
 	constraint "rbac-policies_roles.fkey-policy_id" foreign key (policy_id)
@@ -125,5 +126,6 @@ create table if not exists "rbac-policies_roles" (
 		on delete cascade,
 	constraint "rbac-policies_roles.fkey-role_id" foreign key (role_id)
 		references roles(_id)
-		on delete cascade
+		on delete cascade,
+	constraint "rbac-policies_roles.check-attrs" check(jsonb_typeof(attrs) = 'object')
 );

--- a/datastore/schema.sql
+++ b/datastore/schema.sql
@@ -1,9 +1,12 @@
 create table if not exists "access-policies" (
 	_id   text    not null,
 	_rev  integer not null,
+	name  text,
 	rules jsonb,
 
-	constraint "access-policies.pkey" primary key (_id)
+	constraint "access-policies.pkey" primary key (_id),
+	constraint "access-policies.check-name" check (name <> ''),
+	constraint "access-policies.check-rules" check(jsonb_typeof(rules) = 'array')
 );
 
 create table if not exists collections (

--- a/proto/gk/v1/gatekeeper.proto
+++ b/proto/gk/v1/gatekeeper.proto
@@ -177,8 +177,8 @@ message Principal {
 
 // Access policies
 message AccessPolicy {
-	string id   = 1;
-	string name = 2;
+	string          id   = 1;
+	optional string name = 2;
 
 	repeated Principal        principals = 3;
 	repeated AccessPolicyRule rules      = 4;
@@ -204,7 +204,7 @@ message CheckAccessResponse {
 
 message CreateAccessPolicyRequest {
 	optional string id   = 1;
-	string          name = 2;
+	optional string name = 2;
 
 	repeated Principal        principals = 3;
 	repeated AccessPolicyRule rules      = 4;

--- a/proto/gk/v1/gatekeeper.proto
+++ b/proto/gk/v1/gatekeeper.proto
@@ -258,12 +258,24 @@ message RemoveCollectionMemberResponse {}
 
 // Events
 message Event {
+	// A name that uniquely identify the event.
+	// Supported names are,
+	//   - "request/cache.rebuild:access"
+	//   - "request/cache.rebuild:rbac"
 	string                    name      = 1;
 	google.protobuf.Any       payload   = 3;
 	google.protobuf.Timestamp timestamp = 2;
 }
 
 message ConsumeEventResponse {}
+
+message RebuildAccessCacheEventPayload {
+	repeated string ids = 1;
+}
+
+message RebuildRbacCacheEventPayload {
+	repeated string ids = 1;
+}
 
 // Identities
 message Identity {

--- a/proto/gk/v1/gatekeeper.proto
+++ b/proto/gk/v1/gatekeeper.proto
@@ -314,8 +314,8 @@ message UpdateIdentityRequest {
 
 // RBAC policies
 message RbacPolicy {
-	string id   = 1;
-	string name = 2;
+	string          id   = 1;
+	optional string name = 2;
 
 	repeated Principal      principals = 3;
 	repeated RbacPolicyRule rules      = 4;
@@ -341,7 +341,7 @@ message CheckRbacResponse {
 
 message CreateRbacPolicyRequest {
 	optional string id   = 1;
-	string          name = 2;
+	optional string name = 2;
 
 	repeated Principal      principals = 3;
 	repeated RbacPolicyRule rules      = 4;

--- a/src/datastore/CMakeLists.txt
+++ b/src/datastore/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(datastore
 	datastore.h
 	identities.cpp identities.h
 	pg.cpp pg.h
+	policies.h
 	rbac-policies.cpp rbac-policies.h
 	redis.cpp redis.h
 	roles.cpp roles.h

--- a/src/datastore/CMakeLists.txt
+++ b/src/datastore/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(datastore
 target_link_libraries(datastore
 	PUBLIC
 		${PROJECT_NAME}::err
+		glaze::glaze
 		hiredis::hiredis_static
 		pqxx
 	PRIVATE

--- a/src/datastore/access-policies.cpp
+++ b/src/datastore/access-policies.cpp
@@ -53,15 +53,7 @@ void AccessPolicy::store() const {
 		returning _rev;
 	)";
 
-	pg::result_t res;
-	try {
-		res = pg::exec(qry, _data.id, _rev, _data.name, _data.rules);
-	} catch (pqxx::check_violation &) {
-		throw err::DatastoreInvalidIdentityData();
-	} catch (pg::unique_violation_t &) {
-		throw err::DatastoreDuplicateIdentity();
-	}
-
+	auto res = pg::exec(qry, _data.id, _rev, _data.name, _data.rules);
 	if (res.empty()) {
 		throw err::DatastoreRevisionMismatch();
 	}

--- a/src/datastore/access-policies.cpp
+++ b/src/datastore/access-policies.cpp
@@ -24,7 +24,9 @@ AccessPolicy::AccessPolicy(Data &&data) noexcept : _data(std::move(data)), _rev(
 
 AccessPolicy::AccessPolicy(const pg::row_t &r) :
 	_data({
-		.id = r["_id"].as<std::string>(),
+		.id    = r["_id"].as<std::string>(),
+		.name  = r["name"].as<Data::name_t>(),
+		.rules = r["rules"].as<Data::rules_t>(),
 	}),
 	_rev(r["_rev"].as<int>()) {}
 
@@ -167,7 +169,8 @@ const Policies AccessPolicy::Cache::check(
 	Policies policies;
 	for (int i = 0; i < reply->elements; i += 2) {
 		policies.push_back({
-			.id = reply->element[i]->str,
+			.attrs = reply->element[i + 1]->str,
+			.id    = reply->element[i]->str,
 		});
 	}
 
@@ -187,7 +190,9 @@ AccessPolicy RetrieveAccessPolicy(const std::string &id) {
 	std::string_view qry = R"(
 		select
 			_id,
-			_rev
+			_rev,
+			name,
+			rules
 		from "access-policies"
 		where
 			_id = $1::text;

--- a/src/datastore/access-policies.cpp
+++ b/src/datastore/access-policies.cpp
@@ -7,6 +7,7 @@
 #include "err/errors.h"
 
 #include "collections.h"
+#include "redis.h"
 
 namespace datastore {
 AccessPolicy::AccessPolicy(const AccessPolicy::Data &data) noexcept : _data(data), _rev(0) {
@@ -165,9 +166,9 @@ const Policies AccessPolicy::Cache::check(
 
 	Policies policies;
 	for (int i = 0; i < reply->elements; i += 2) {
-		policies.push_back(Policy({
+		policies.push_back({
 			.id = reply->element[i]->str,
-		}));
+		});
 	}
 
 	return policies;

--- a/src/datastore/access-policies.cpp
+++ b/src/datastore/access-policies.cpp
@@ -88,7 +88,7 @@ void AccessPolicy::addCollection(const AccessPolicy::collection_t &id) const {
 			Cache cache({
 				.identity = mid,
 				.policy   = _data.id,
-				.resource = rule.resource,
+				.rule     = rule,
 			});
 
 			cache.store();
@@ -151,7 +151,7 @@ void AccessPolicy::addIdentity(const AccessPolicy::identity_t &id) const {
 		Cache cache({
 			.identity = id,
 			.policy   = _data.id,
-			.resource = rule.resource,
+			.rule     = rule,
 		});
 
 		cache.store();
@@ -179,7 +179,7 @@ void AccessPolicy::Cache::discard() const {
 
 void AccessPolicy::Cache::store() const {
 	auto conn = datastore::redis::conn();
-	conn.cmd("hset %s %s %s", key().c_str(), policy.c_str(), "");
+	conn.cmd("hset %s %s %s", key().c_str(), policy.c_str(), rule.attrs.c_str());
 }
 
 AccessPolicy RetrieveAccessPolicy(const std::string &id) {

--- a/src/datastore/access-policies.h
+++ b/src/datastore/access-policies.h
@@ -31,11 +31,11 @@ public:
 
 		static const Policies check(const std::string &identity, const std::string &resource);
 
-		static constexpr std::string key(const std::string &identity, const std::string &resource) {
+		static const std::string key(const std::string &identity, const std::string &resource) {
 			return "access:(" + identity + ")›[" + resource + "]";
 		}
 
-		constexpr std::string key() const noexcept { return key(identity, rule.resource); };
+		const std::string key() const noexcept { return key(identity, rule.resource); };
 
 		void discard() const;
 		void store() const;

--- a/src/datastore/access-policies.h
+++ b/src/datastore/access-policies.h
@@ -18,8 +18,8 @@ public:
 	using identities_t  = std::set<identity_t>;
 
 	struct Rule {
-		const std::string attrs;
-		const std::string resource;
+		std::string attrs;
+		std::string resource;
 
 		bool operator<(const Rule &rhs) const noexcept { return resource < rhs.resource; }
 	};
@@ -101,7 +101,14 @@ template <> struct nullness<access_rules_t> {
 };
 
 template <> struct string_traits<access_rules_t> {
-	static access_rules_t from_string(std::string_view text) { return {}; }
+	static access_rules_t from_string(std::string_view text) {
+		access_rules_t result;
+		if (glz::read_json(result, text)) {
+			throw pqxx::conversion_error("Failed to read json");
+		}
+
+		return result;
+	}
 
 	static char *into_buf(char *begin, char *end, access_rules_t const &value) {
 		const auto buffer = glz::write_json(value);

--- a/src/datastore/access-policies.h
+++ b/src/datastore/access-policies.h
@@ -60,6 +60,9 @@ public:
 	const std::string &id() const noexcept { return _data.id; }
 	const int         &rev() const noexcept { return _rev; }
 
+	const identities_t identities(bool expand = false) const;
+	void               addIdentity(const identity_t &id) const;
+
 	const Data::name_t &name() const noexcept { return _data.name; }
 	void                name(const std::string &name) noexcept { _data.name = name; }
 	void                name(std::string &&name) noexcept { _data.name = std::move(name); }
@@ -67,9 +70,6 @@ public:
 	const Data::rules_t &rules() const noexcept { return _data.rules; }
 
 	void addCollection(const collection_t &id) const;
-
-	const identities_t identities(bool expand = false) const;
-	void               addIdentity(const identity_t &id) const;
 
 	void store() const;
 

--- a/src/datastore/access-policies.h
+++ b/src/datastore/access-policies.h
@@ -8,7 +8,6 @@
 
 #include "pg.h"
 #include "policies.h"
-#include "redis.h"
 
 namespace datastore {
 class AccessPolicy {
@@ -90,21 +89,21 @@ template <> struct glz::meta<datastore::AccessPolicy::Rule> {
 };
 
 namespace pqxx {
-using rules_t = datastore::AccessPolicy::Data::rules_t;
+using access_rules_t = datastore::AccessPolicy::Data::rules_t;
 
-template <> struct nullness<rules_t> {
+template <> struct nullness<access_rules_t> {
 	static constexpr bool has_null    = {true};
 	static constexpr bool always_null = {false};
 
-	static bool is_null(const rules_t &value) { return value.empty(); }
+	static bool is_null(const access_rules_t &value) { return value.empty(); }
 
-	[[nodiscard]] static rules_t null() { return {}; }
+	[[nodiscard]] static access_rules_t null() { return {}; }
 };
 
-template <> struct string_traits<rules_t> {
-	static rules_t from_string(std::string_view text) { return {}; }
+template <> struct string_traits<access_rules_t> {
+	static access_rules_t from_string(std::string_view text) { return {}; }
 
-	static char *into_buf(char *begin, char *end, rules_t const &value) {
+	static char *into_buf(char *begin, char *end, access_rules_t const &value) {
 		const auto buffer = glz::write_json(value);
 		if (buffer.size() > (end - begin)) {
 			throw pqxx::conversion_overrun("Not enough buffer capacity");
@@ -114,7 +113,7 @@ template <> struct string_traits<rules_t> {
 		return (begin + buffer.size() + 1);
 	}
 
-	static std::size_t size_buffer(rules_t const &value) noexcept {
+	static std::size_t size_buffer(access_rules_t const &value) noexcept {
 		std::size_t size = 2; // `[]`
 		for (const auto &rule : value) {
 			size += 3;                             // `{}` + `,`

--- a/src/datastore/access-policies.h
+++ b/src/datastore/access-policies.h
@@ -64,4 +64,6 @@ private:
 using AccessPolicies = std::vector<AccessPolicy>;
 
 AccessPolicy RetrieveAccessPolicy(const std::string &id);
+
+std::set<std::string> RetrieveAccessPolicyIdentities(const std::string &id);
 } // namespace datastore

--- a/src/datastore/access-policies.h
+++ b/src/datastore/access-policies.h
@@ -66,7 +66,9 @@ public:
 	void                name(std::string &&name) noexcept { _data.name = std::move(name); }
 
 	void addCollection(const collection_t &id) const;
-	void addIdentity(const identity_t &id) const;
+
+	const identities_t identities(bool expand = false) const;
+	void               addIdentity(const identity_t &id) const;
 
 	void store() const;
 
@@ -78,8 +80,6 @@ private:
 using AccessPolicies = std::vector<AccessPolicy>;
 
 AccessPolicy RetrieveAccessPolicy(const std::string &id);
-
-std::set<std::string> RetrieveAccessPolicyIdentities(const std::string &id);
 } // namespace datastore
 
 template <> struct glz::meta<datastore::AccessPolicy::Rule> {

--- a/src/datastore/access-policies.h
+++ b/src/datastore/access-policies.h
@@ -28,7 +28,7 @@ public:
 	struct Cache {
 		const std::string identity;
 		const std::string policy;
-		const std::string resource;
+		const Rule        rule;
 
 		static const Policies check(const std::string &identity, const std::string &resource);
 
@@ -36,7 +36,7 @@ public:
 			return "access:(" + identity + ")›[" + resource + "]";
 		}
 
-		constexpr std::string key() const noexcept { return key(identity, resource); };
+		constexpr std::string key() const noexcept { return key(identity, rule.resource); };
 
 		void discard() const;
 		void store() const;
@@ -64,6 +64,8 @@ public:
 	const Data::name_t &name() const noexcept { return _data.name; }
 	void                name(const std::string &name) noexcept { _data.name = name; }
 	void                name(std::string &&name) noexcept { _data.name = std::move(name); }
+
+	const Data::rules_t &rules() const noexcept { return _data.rules; }
 
 	void addCollection(const collection_t &id) const;
 

--- a/src/datastore/access-policies_test.cpp
+++ b/src/datastore/access-policies_test.cpp
@@ -71,6 +71,44 @@ TEST_F(AccessPoliciesTest, identities) {
 	}
 }
 
+TEST_F(AccessPoliciesTest, retrieve) {
+	// Success: retrieve data
+	{
+		std::string_view qry = R"(
+			insert into "access-policies" (
+				_id,
+				_rev,
+				rules
+			) values (
+				$1::text,
+				$2::integer,
+				$3::jsonb
+			);
+		)";
+
+		try {
+			datastore::pg::exec(
+				qry,
+				"_id:AccessPoliciesTest.retrieve",
+				1328,
+				R"([{"attrs": "attrs:AccessPoliciesTest.retrieve", "resource":"resource:AccessPoliciesTest.retrieve"}])");
+		} catch (const std::exception &e) {
+			FAIL() << e.what();
+		}
+
+		auto policy = datastore::RetrieveAccessPolicy("_id:AccessPoliciesTest.retrieve");
+		EXPECT_EQ(1328, policy.rev());
+		EXPECT_FALSE(policy.name());
+
+		const auto &rules = policy.rules();
+		ASSERT_EQ(1, rules.size());
+
+		const auto rule = rules.cbegin();
+		EXPECT_EQ("attrs:AccessPoliciesTest.retrieve", rule->attrs);
+		EXPECT_EQ("resource:AccessPoliciesTest.retrieve", rule->resource);
+	}
+}
+
 TEST_F(AccessPoliciesTest, rev) {
 	// Success: revision increment
 	{

--- a/src/datastore/access-policies_test.cpp
+++ b/src/datastore/access-policies_test.cpp
@@ -26,41 +26,6 @@ protected:
 	static void TearDownTestSuite() { datastore::testing::teardown(); }
 };
 
-TEST_F(AccessPoliciesTest, create) {
-	// Success: add policy
-	{
-		const datastore::AccessPolicy policy({
-			.name = "name:AccessPoliciesTest.add",
-		});
-		EXPECT_NO_THROW(policy.store());
-
-		EXPECT_NO_THROW(datastore::RetrieveAccessPolicy(policy.id()));
-
-		// cleanup
-		EXPECT_NO_THROW(policy.discard());
-	}
-
-	// Success: add an access entry to a policy
-	{
-		const datastore::AccessPolicy policy({
-			.name = "name:AccessPoliciesTest.add-access",
-		});
-		EXPECT_NO_THROW(policy.store());
-
-		// store access
-		auto record = datastore::AccessPolicy::Record(
-			"principal-id:AccessPoliciesTest.add-access",
-			"resource-id:AccessPoliciesTest.add-access");
-		EXPECT_NO_THROW(policy.add(record));
-
-		EXPECT_EQ(record.check().size(), 1);
-
-		// cleanup
-		EXPECT_NO_THROW(policy.discard());
-		EXPECT_NO_THROW(record.discard());
-	}
-}
-
 TEST_F(AccessPoliciesTest, retrieveIdentities) {
 	// Success: retrieve identities
 	{
@@ -84,8 +49,8 @@ TEST_F(AccessPoliciesTest, retrieveIdentities) {
 		});
 		ASSERT_NO_THROW(policy.store());
 
-		ASSERT_NO_THROW(policy.addCollectionPrincipal(collection.id()));
-		ASSERT_NO_THROW(policy.addIdentityPrincipal(identities[1].id()));
+		ASSERT_NO_THROW(policy.addCollection(collection.id()));
+		ASSERT_NO_THROW(policy.addIdentity(identities[1].id()));
 
 		const auto results = datastore::RetrieveAccessPolicyIdentities(policy.id());
 		EXPECT_EQ(2, results.size());

--- a/src/datastore/access-policies_test.cpp
+++ b/src/datastore/access-policies_test.cpp
@@ -26,7 +26,7 @@ protected:
 	static void TearDownTestSuite() { datastore::testing::teardown(); }
 };
 
-TEST_F(AccessPoliciesTest, retrieveIdentities) {
+TEST_F(AccessPoliciesTest, identities) {
 	// Success: retrieve identities
 	{
 		const datastore::Identities identities({
@@ -52,11 +52,21 @@ TEST_F(AccessPoliciesTest, retrieveIdentities) {
 		ASSERT_NO_THROW(policy.addCollection(collection.id()));
 		ASSERT_NO_THROW(policy.addIdentity(identities[1].id()));
 
-		const auto results = datastore::RetrieveAccessPolicyIdentities(policy.id());
-		EXPECT_EQ(2, results.size());
+		// without expand should only return direct identities
+		{
+			const auto results = policy.identities();
+			EXPECT_EQ(1, results.size());
+			EXPECT_TRUE(results.contains(identities[1].id()));
+		}
 
-		for (const auto &idn : identities) {
-			EXPECT_TRUE(results.contains(idn.id()));
+		// with expand should return direct and indirect identities
+		{
+			const auto results = policy.identities(true);
+			EXPECT_EQ(2, results.size());
+
+			for (const auto &idn : identities) {
+				EXPECT_TRUE(results.contains(idn.id()));
+			}
 		}
 	}
 }

--- a/src/datastore/collections.cpp
+++ b/src/datastore/collections.cpp
@@ -46,6 +46,37 @@ void Collection::add(const member_t &mid) const {
 	}
 }
 
+const Collection::members_t Collection::members() const {
+	std::string_view qry = R"(
+		select
+			identity_id
+		from
+			collections_identities
+		where
+			collection_id = $1::text;
+	)";
+
+	auto res = pg::exec(qry, _data.id);
+
+	members_t members;
+	for (const auto &r : res) {
+		members.insert(r["identity_id"].as<member_t>());
+	}
+
+	return members;
+}
+
+void Collection::remove(const member_t &mid) const {
+	std::string_view qry = R"(
+		delete from collections_identities
+		where
+			collection_id = $1::text and
+			identity_id = $2::text;
+	)";
+
+	pg::exec(qry, _data.id, mid);
+}
+
 void Collection::store() const {
 	std::string_view qry = R"(
 		insert into collections as t (
@@ -76,37 +107,6 @@ void Collection::store() const {
 	}
 
 	_rev = res.at(0, 0).as<int>();
-}
-
-const Collection::members_t Collection::members() const {
-	std::string_view qry = R"(
-		select
-			identity_id
-		from
-			collections_identities
-		where
-			collection_id = $1::text;
-	)";
-
-	auto res = pg::exec(qry, _data.id);
-
-	members_t members;
-	for (const auto &r : res) {
-		members.insert(r["identity_id"].as<member_t>());
-	}
-
-	return members;
-}
-
-void Collection::remove(const member_t &mid) const {
-	std::string_view qry = R"(
-		delete from collections_identities
-		where
-			collection_id = $1::text and
-			identity_id = $2::text;
-	)";
-
-	pg::exec(qry, _data.id, mid);
 }
 
 Collection RetrieveCollection(const std::string &id) {

--- a/src/datastore/collections.h
+++ b/src/datastore/collections.h
@@ -44,5 +44,6 @@ private:
 
 using Collections = std::vector<Collection>;
 
-Collection RetrieveCollection(const std::string &id);
+Collection                  RetrieveCollection(const std::string &id);
+const Collection::members_t RetrieveCollectionMembers(const std::string &id);
 } // namespace datastore

--- a/src/datastore/collections_test.cpp
+++ b/src/datastore/collections_test.cpp
@@ -196,6 +196,33 @@ TEST_F(CollectionsTest, retrieve) {
 		EXPECT_EQ("name:CollectionsTest.retrieve", collection.name());
 	}
 
+	// Success: retrieve members
+	{
+		const datastore::Collection collection({
+			.name = "name:CollectionsTest.retrieve-members",
+		});
+		ASSERT_NO_THROW(collection.store());
+
+		const datastore::Identity identity({
+			.sub = "sub:CollectionsTest.retrieve-members",
+		});
+		ASSERT_NO_THROW(identity.store());
+
+		// expect no entries before adding to collection
+		{
+			const auto members = datastore::RetrieveCollectionMembers(collection.id());
+			EXPECT_EQ(0, members.size());
+		}
+
+		ASSERT_NO_THROW(collection.add(identity.id()));
+
+		// expect single entry after adding one member
+		{
+			const auto members = datastore::RetrieveCollectionMembers(collection.id());
+			EXPECT_EQ(1, members.size());
+		}
+	}
+
 	// Error: not found
 	{ EXPECT_THROW(datastore::RetrieveCollection("_id:dummy"), err::DatastoreCollectionNotFound); }
 }

--- a/src/datastore/identities.cpp
+++ b/src/datastore/identities.cpp
@@ -81,26 +81,6 @@ void Identity::store() const {
 	_rev = res.at(0, 0).as<int>();
 }
 
-std::vector<std::string> ListIdentitiesInCollection(const std::string &id) {
-	// FIXME: make this query recursive when collections can have parents
-	std::string_view qry = R"(
-		select
-			identity_id
-		from collections_identities
-		where
-			collection_id = $1::text;
-	)";
-
-	auto res = pg::exec(qry, id);
-
-	std::vector<std::string> identities;
-	for (auto row : res) {
-		identities.push_back(row["identity_id"].as<std::string>());
-	}
-
-	return identities;
-}
-
 Identity RetrieveIdentity(const std::string &id) {
 	std::string_view qry = R"(
 		select

--- a/src/datastore/identities.cpp
+++ b/src/datastore/identities.cpp
@@ -81,26 +81,6 @@ void Identity::store() const {
 	_rev = res.at(0, 0).as<int>();
 }
 
-Identity RetrieveIdentity(const std::string &id) {
-	std::string_view qry = R"(
-		select
-			_id,
-			_rev,
-			sub,
-			attrs
-		from identities
-		where
-			_id = $1::text;
-	)";
-
-	auto res = pg::exec(qry, id);
-	if (res.empty()) {
-		throw err::DatastoreIdentityNotFound();
-	}
-
-	return Identity(res[0]);
-}
-
 Identities LookupIdentities(const std::string &sub) {
 	std::string_view qry = R"(
 		select
@@ -121,5 +101,25 @@ Identities LookupIdentities(const std::string &sub) {
 	}
 
 	return identities;
+}
+
+Identity RetrieveIdentity(const std::string &id) {
+	std::string_view qry = R"(
+		select
+			_id,
+			_rev,
+			sub,
+			attrs
+		from identities
+		where
+			_id = $1::text;
+	)";
+
+	auto res = pg::exec(qry, id);
+	if (res.empty()) {
+		throw err::DatastoreIdentityNotFound();
+	}
+
+	return Identity(res[0]);
 }
 } // namespace datastore

--- a/src/datastore/identities.h
+++ b/src/datastore/identities.h
@@ -46,7 +46,6 @@ private:
 
 using Identities = std::vector<Identity>;
 
-std::vector<std::string> ListIdentitiesInCollection(const std::string &id);
-Identity                 RetrieveIdentity(const std::string &id);
-Identities               LookupIdentities(const std::string &sub);
+Identity   RetrieveIdentity(const std::string &id);
+Identities LookupIdentities(const std::string &sub);
 } // namespace datastore

--- a/src/datastore/identities.h
+++ b/src/datastore/identities.h
@@ -46,6 +46,6 @@ private:
 
 using Identities = std::vector<Identity>;
 
-Identity   RetrieveIdentity(const std::string &id);
 Identities LookupIdentities(const std::string &sub);
+Identity   RetrieveIdentity(const std::string &id);
 } // namespace datastore

--- a/src/datastore/identities_test.cpp
+++ b/src/datastore/identities_test.cpp
@@ -45,31 +45,6 @@ TEST_F(IdentitiesTest, discard) {
 	EXPECT_EQ(0, count);
 }
 
-TEST_F(IdentitiesTest, listInCollection) {
-	// Success:
-	{
-		const datastore::Identity identity({
-			.sub = "sub:IdentitiesTest.listInCollection",
-		});
-		ASSERT_NO_THROW(identity.store());
-
-		const datastore::Collection collection({
-			.name = "collection:IdentitiesTest.listInCollection",
-		});
-		ASSERT_NO_THROW(collection.store());
-
-		// expect no entries before adding to collection
-		auto identities = datastore::ListIdentitiesInCollection(collection.id());
-		EXPECT_EQ(0, identities.size());
-
-		ASSERT_NO_THROW(collection.add(identity.id()));
-
-		// expect single entry
-		identities = datastore::ListIdentitiesInCollection(collection.id());
-		EXPECT_EQ(1, identities.size());
-	}
-}
-
 TEST_F(IdentitiesTest, lookup) {
 	// Success:
 	{

--- a/src/datastore/policies.h
+++ b/src/datastore/policies.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace datastore {
+struct Policy {
+	const std::string attrs;
+	const std::string id;
+};
+
+using Policies = std::vector<Policy>;
+} // namespace datastore

--- a/src/datastore/rbac-policies.cpp
+++ b/src/datastore/rbac-policies.cpp
@@ -203,9 +203,9 @@ const RbacPolicy::Principals RbacPolicy::principals() const {
 const RbacPolicy::Rules RbacPolicy::rules() const {
 	std::string_view qry = R"(
 		select
+			attrs,
 			role_id
-		from
-			"rbac-policies_roles"
+		from "rbac-policies_roles"
 		where
 			policy_id = $1::text;
 	)";
@@ -215,6 +215,7 @@ const RbacPolicy::Rules RbacPolicy::rules() const {
 	Rules rules;
 	for (const auto &r : res) {
 		rules.push_back(Rule({
+			.attrs  = r["attrs"].as<Rule::attrs_t>(),
 			.roleId = r["role_id"].as<std::string>(),
 		}));
 	}
@@ -262,7 +263,8 @@ const Policies RbacPolicy::Cache::check(
 	Policies policies;
 	for (int i = 0; i < reply->elements; i += 2) {
 		policies.push_back({
-			.id = reply->element[i]->str,
+			.attrs = reply->element[i + 1]->str,
+			.id    = reply->element[i]->str,
 		});
 	}
 

--- a/src/datastore/rbac-policies.cpp
+++ b/src/datastore/rbac-policies.cpp
@@ -271,7 +271,7 @@ const Policies RbacPolicy::Cache::check(
 
 void RbacPolicy::Cache::store() const {
 	auto conn = datastore::redis::conn();
-	conn.cmd("hset %s %s %s", key().c_str(), policy.c_str(), rule.attrs->c_str());
+	conn.cmd("hset %s %s %s", key().c_str(), policy.c_str(), rule.attrs.value_or("").c_str());
 }
 
 RbacPolicy RetrieveRbacPolicy(const std::string &id) {

--- a/src/datastore/rbac-policies.cpp
+++ b/src/datastore/rbac-policies.cpp
@@ -271,6 +271,10 @@ const Policies RbacPolicy::Cache::check(
 	return policies;
 }
 
+void RbacPolicy::Cache::discard() const {
+	datastore::redis::conn().cmd("del %s", key().c_str());
+}
+
 void RbacPolicy::Cache::store() const {
 	auto conn = datastore::redis::conn();
 	conn.cmd("hset %s %s %s", key().c_str(), policy.c_str(), rule.attrs.value_or("").c_str());

--- a/src/datastore/rbac-policies.h
+++ b/src/datastore/rbac-policies.h
@@ -39,6 +39,7 @@ public:
 
 		const std::string key() const noexcept { return key(identity, permission); };
 
+		void discard() const;
 		void store() const;
 	};
 

--- a/src/datastore/rbac-policies.h
+++ b/src/datastore/rbac-policies.h
@@ -70,6 +70,9 @@ public:
 	const std::string &id() const noexcept { return _data.id; }
 	const int         &rev() const noexcept { return _rev; }
 
+	const identities_t identities(bool expand = false) const;
+	void               addIdentity(const identity_t &id) const;
+
 	const Data::name_t &name() const noexcept { return _data.name; }
 	void                name(const std::string &name) noexcept { _data.name = name; }
 	void                name(std::string &&name) noexcept { _data.name = std::move(name); }
@@ -77,7 +80,6 @@ public:
 	const Principals principals() const;
 	void             addPrincipal(const Principal principal) const;
 	void             addCollection(const collection_t &id) const;
-	void             addIdentity(const identity_t &id) const;
 
 	const Rules rules() const;
 	void        addRule(const Rule &rule) const;

--- a/src/datastore/rbac-policies.h
+++ b/src/datastore/rbac-policies.h
@@ -33,12 +33,11 @@ public:
 
 		static const Policies check(const std::string &identity, const std::string &permission);
 
-		static constexpr std::string key(
-			const std::string &identity, const std::string &permission) {
+		static const std::string key(const std::string &identity, const std::string &permission) {
 			return "rbac:(" + identity + ")›[" + permission + "]";
 		}
 
-		constexpr std::string key() const noexcept { return key(identity, permission); };
+		const std::string key() const noexcept { return key(identity, permission); };
 
 		void store() const;
 	};

--- a/src/datastore/roles.h
+++ b/src/datastore/roles.h
@@ -50,18 +50,18 @@ Role RetrieveRole(const std::string &id);
 } // namespace datastore
 
 namespace pqxx {
-using T = datastore::Role::permissions_t;
+using permissions_t = datastore::Role::permissions_t;
 
-template <> struct nullness<T> {
+template <> struct nullness<permissions_t> {
 	static constexpr bool has_null = {true};
 
-	[[nodiscard]] static T null() { return {}; }
+	[[nodiscard]] static permissions_t null() { return {}; }
 };
 
-template <> struct string_traits<T> {
-	static T from_string(std::string_view text) {
+template <> struct string_traits<permissions_t> {
+	static permissions_t from_string(std::string_view text) {
 		// FIXME: this is a very optimistic lookup, expects `{string,string}` with no escaped chars
-		T result;
+		permissions_t result;
 
 		using size_t = std::string_view::size_type;
 		for (size_t next, pos = 1; pos < text.size() - 1; pos = next + 1) {

--- a/src/service/grpc.cpp
+++ b/src/service/grpc.cpp
@@ -268,7 +268,17 @@ grpc::ServerUnaryReactor *Grpc::ConsumeEvent(
 
 		for (const auto &id : payload.ids()) {
 			const auto policy = datastore::RetrieveAccessPolicy(id);
-			// TODO:
+			for (const auto &identity : policy.identities()) {
+				for (const auto &rule : policy.rules()) {
+					const datastore::AccessPolicy::Cache cache({
+						.identity = identity,
+						.policy   = policy.id(),
+						.rule     = rule,
+					});
+
+					cache.store();
+				}
+			}
 		}
 	} else if (request->name() == "request/cache.rebuild:rbac") {
 		gk::v1::RebuildRbacCacheEventPayload payload;

--- a/src/service/grpc.cpp
+++ b/src/service/grpc.cpp
@@ -265,6 +265,42 @@ grpc::ServerUnaryReactor *Grpc::RemoveCollectionMember(
 	return reactor;
 }
 
+// Events
+grpc::ServerUnaryReactor *Grpc::ConsumeEvent(
+	grpc::CallbackServerContext *context, const gk::v1::Event *request,
+	gk::v1::ConsumeEventResponse *response) {
+	auto *reactor = context->DefaultReactor();
+
+	if (request->name() == "request/cache.rebuild:access") {
+		gk::v1::RebuildAccessCacheEventPayload payload;
+		if (!request->payload().UnpackTo(&payload)) {
+			reactor->Finish(grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "Invalid payload"));
+			return reactor;
+		}
+
+		for (const auto &id : payload.ids()) {
+			const auto policy = datastore::RetrieveAccessPolicy(id);
+			// TODO:
+		}
+	} else if (request->name() == "request/cache.rebuild:rbac") {
+		gk::v1::RebuildRbacCacheEventPayload payload;
+		if (!request->payload().UnpackTo(&payload)) {
+			reactor->Finish(grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "Invalid payload"));
+			return reactor;
+		}
+
+		for (const auto &id : payload.ids()) {
+			// TODO:
+		}
+	} else {
+		reactor->Finish(grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "Unknown event"));
+		return reactor;
+	}
+
+	reactor->Finish(grpc::Status::OK);
+	return reactor;
+}
+
 // Identities
 grpc::ServerUnaryReactor *Grpc::CreateIdentity(
 	grpc::CallbackServerContext *context, const gk::v1::CreateIdentityRequest *request,

--- a/src/service/grpc.h
+++ b/src/service/grpc.h
@@ -44,6 +44,11 @@ public:
 		grpc::CallbackServerContext *context, const gk::v1::RemoveCollectionMemberRequest *request,
 		gk::v1::RemoveCollectionMemberResponse *response) override;
 
+	// Events
+	grpc::ServerUnaryReactor *ConsumeEvent(
+		grpc::CallbackServerContext *context, const gk::v1::Event *request,
+		gk::v1::ConsumeEventResponse *response) override;
+
 	// Identities
 	grpc::ServerUnaryReactor *CreateIdentity(
 		grpc::CallbackServerContext *context, const gk::v1::CreateIdentityRequest *request,

--- a/src/service/grpc_test.cpp
+++ b/src/service/grpc_test.cpp
@@ -104,7 +104,7 @@ TEST_F(GrpcTest, CheckRbac) {
 		EXPECT_TRUE(peer.test_status_set());
 		EXPECT_TRUE(peer.test_status().ok());
 		EXPECT_EQ(peer.reactor(), reactor);
-		EXPECT_EQ(response.policies().size(), 0);
+		EXPECT_EQ(0, response.policies().size());
 	}
 
 	// Success: returns policy when found
@@ -140,7 +140,7 @@ TEST_F(GrpcTest, CheckRbac) {
 		EXPECT_TRUE(peer.test_status_set());
 		EXPECT_TRUE(peer.test_status().ok());
 		EXPECT_EQ(peer.reactor(), reactor);
-		EXPECT_EQ(response.policies().size(), 1);
+		EXPECT_EQ(1, response.policies().size());
 	}
 }
 

--- a/src/service/grpc_test.cpp
+++ b/src/service/grpc_test.cpp
@@ -33,24 +33,9 @@ protected:
 	static void TearDownTestSuite() { datastore::testing::teardown(); }
 };
 
-// Access Policies
+// Access control checks
 TEST_F(GrpcTest, CheckAccess) {
 	service::Grpc service;
-
-	// Success: returns empty list when no policy set
-	{
-		grpc::CallbackServerContext           ctx;
-		grpc::testing::DefaultReactorTestPeer peer(&ctx);
-		gk::v1::CheckAccessResponse           response;
-
-		gk::v1::CheckAccessRequest request;
-
-		auto reactor = service.CheckAccess(&ctx, &request, &response);
-		EXPECT_TRUE(peer.test_status_set());
-		EXPECT_TRUE(peer.test_status().ok());
-		EXPECT_EQ(peer.reactor(), reactor);
-		EXPECT_EQ(response.policies().size(), 0);
-	}
 
 	// Success: returns policy when found
 	{
@@ -85,27 +70,12 @@ TEST_F(GrpcTest, CheckAccess) {
 		EXPECT_TRUE(peer.test_status_set());
 		EXPECT_TRUE(peer.test_status().ok());
 		EXPECT_EQ(peer.reactor(), reactor);
-		EXPECT_EQ(response.policies().size(), 1);
+		EXPECT_EQ(1, response.policies().size());
 	}
 }
 
 TEST_F(GrpcTest, CheckRbac) {
 	service::Grpc service;
-
-	// Success: returns empty list when no policy set
-	{
-		grpc::CallbackServerContext           ctx;
-		grpc::testing::DefaultReactorTestPeer peer(&ctx);
-		gk::v1::CheckRbacResponse             response;
-
-		gk::v1::CheckRbacRequest request;
-
-		auto reactor = service.CheckRbac(&ctx, &request, &response);
-		EXPECT_TRUE(peer.test_status_set());
-		EXPECT_TRUE(peer.test_status().ok());
-		EXPECT_EQ(peer.reactor(), reactor);
-		EXPECT_EQ(0, response.policies().size());
-	}
 
 	// Success: returns policy when found
 	{
@@ -144,6 +114,7 @@ TEST_F(GrpcTest, CheckRbac) {
 	}
 }
 
+// Access Policies
 TEST_F(GrpcTest, CreateAccessPolicy) {
 	service::Grpc service;
 

--- a/src/service/grpc_test.cpp
+++ b/src/service/grpc_test.cpp
@@ -72,7 +72,7 @@ TEST_F(GrpcTest, CheckAccess) {
 		const datastore::AccessPolicy::Cache cache({
 			.identity = identity.id(),
 			.policy   = policy.id(),
-			.resource = resource,
+			.rule     = {.resource = resource},
 		});
 		ASSERT_NO_THROW(cache.store());
 

--- a/src/service/mappers.cpp
+++ b/src/service/mappers.cpp
@@ -4,8 +4,16 @@
 
 namespace service {
 datastore::AccessPolicy map(const gk::v1::CreateAccessPolicyRequest *from) {
+	datastore::AccessPolicy::Data::rules_t rules;
+	for (const auto &rule : from->rules()) {
+		rules.insert({
+			.resource = rule.resource(),
+		});
+	}
+
 	datastore::AccessPolicy policy({
-		.id = from->id(),
+		.id    = from->id(),
+		.rules = rules,
 	});
 
 	if (from->has_name()) {
@@ -38,35 +46,6 @@ datastore::Identity map(const gk::v1::CreateIdentityRequest *from) {
 	return identity;
 }
 
-void map(const datastore::AccessPolicy &from, gk::v1::AccessPolicy *to) {
-	to->set_id(from.id());
-	if (from.name()) {
-		to->set_name(*from.name());
-	}
-
-	// FIXME: add rules
-}
-
-void map(const datastore::AccessPolicy &from, gk::v1::Policy *to) {
-	to->set_id(from.id());
-
-	// FIXME: add attributes
-}
-
-void map(const datastore::AccessPolicies &from, gk::v1::CheckAccessResponse *to) {
-	for (const auto &policy : from) {
-		auto p = to->add_policies();
-		map(policy, p);
-	}
-}
-
-void map(const datastore::RbacPolicies &from, gk::v1::CheckRbacResponse *to) {
-	for (const auto &policy : from) {
-		auto p = to->add_policies();
-		p->set_id(policy.id());
-	}
-}
-
 datastore::RbacPolicy map(const gk::v1::CreateRbacPolicyRequest *from) {
 	datastore::RbacPolicy rbacPolicy({
 		.id   = from->id(),
@@ -94,6 +73,21 @@ datastore::Role map(const gk::v1::CreateRoleRequest *from) {
 	return role;
 }
 
+void map(const datastore::AccessPolicy &from, gk::v1::AccessPolicy *to) {
+	to->set_id(from.id());
+	if (from.name()) {
+		to->set_name(*from.name());
+	}
+
+	// FIXME: add rules
+}
+
+void map(const datastore::AccessPolicy &from, gk::v1::Policy *to) {
+	to->set_id(from.id());
+
+	// FIXME: add attributes
+}
+
 void map(const datastore::Collection &from, gk::v1::Collection *to) {
 	to->set_id(from.id());
 	to->set_name(from.name());
@@ -112,6 +106,13 @@ void map(const datastore::Identities &from, gk::v1::LookupIdentitiesResponse *to
 	for (const auto &identity : from) {
 		auto i = to->add_data();
 		map(identity, i);
+	}
+}
+
+void map(const datastore::Policies &from, gk::v1::CheckAccessResponse *to) {
+	for (const auto &policy : from) {
+		auto p = to->add_policies();
+		p->set_id(policy.id);
 	}
 }
 
@@ -136,6 +137,13 @@ void map(const datastore::RbacPolicy &from, gk::v1::RbacPolicy *to) {
 			p->set_id(principal.id);
 			p->set_type(static_cast<gk::v1::PrincipalType>(principal.type));
 		}
+	}
+}
+
+void map(const datastore::RbacPolicies &from, gk::v1::CheckRbacResponse *to) {
+	for (const auto &policy : from) {
+		auto p = to->add_policies();
+		p->set_id(policy.id());
 	}
 }
 

--- a/src/service/mappers.cpp
+++ b/src/service/mappers.cpp
@@ -38,7 +38,9 @@ datastore::Identity map(const gk::v1::CreateIdentityRequest *from) {
 
 void map(const datastore::AccessPolicy &from, gk::v1::AccessPolicy *to) {
 	to->set_id(from.id());
-	to->set_name(from.name());
+	if (from.name()) {
+		to->set_name(*from.name());
+	}
 
 	// FIXME: add rules
 }

--- a/src/service/mappers.cpp
+++ b/src/service/mappers.cpp
@@ -4,11 +4,13 @@
 
 namespace service {
 datastore::AccessPolicy map(const gk::v1::CreateAccessPolicyRequest *from) {
-
 	datastore::AccessPolicy policy({
-		.id   = from->id(),
-		.name = from->name(),
+		.id = from->id(),
 	});
+
+	if (from->has_name()) {
+		policy.name(from->name());
+	}
 
 	return policy;
 }

--- a/src/service/mappers.cpp
+++ b/src/service/mappers.cpp
@@ -116,9 +116,18 @@ void map(const datastore::Policies &from, gk::v1::CheckAccessResponse *to) {
 	}
 }
 
+void map(const datastore::Policies &from, gk::v1::CheckRbacResponse *to) {
+	for (const auto &policy : from) {
+		auto p = to->add_policies();
+		p->set_id(policy.id);
+	}
+}
+
 void map(const datastore::RbacPolicy &from, gk::v1::RbacPolicy *to) {
 	to->set_id(from.id());
-	to->set_name(from.name());
+	if (from.name()) {
+		to->set_name(*from.name());
+	}
 
 	// Set role ids from DB table
 	auto rules = from.rules();
@@ -137,13 +146,6 @@ void map(const datastore::RbacPolicy &from, gk::v1::RbacPolicy *to) {
 			p->set_id(principal.id);
 			p->set_type(static_cast<gk::v1::PrincipalType>(principal.type));
 		}
-	}
-}
-
-void map(const datastore::RbacPolicies &from, gk::v1::CheckRbacResponse *to) {
-	for (const auto &policy : from) {
-		auto p = to->add_policies();
-		p->set_id(policy.id());
 	}
 }
 

--- a/src/service/mappers.cpp
+++ b/src/service/mappers.cpp
@@ -47,12 +47,15 @@ datastore::Identity map(const gk::v1::CreateIdentityRequest *from) {
 }
 
 datastore::RbacPolicy map(const gk::v1::CreateRbacPolicyRequest *from) {
-	datastore::RbacPolicy rbacPolicy({
-		.id   = from->id(),
-		.name = from->name(),
+	datastore::RbacPolicy policy({
+		.id = from->id(),
 	});
 
-	return rbacPolicy;
+	if (from->has_name()) {
+		policy.name(from->name());
+	}
+
+	return policy;
 }
 
 datastore::Role map(const gk::v1::CreateRoleRequest *from) {

--- a/src/service/mappers.h
+++ b/src/service/mappers.h
@@ -20,7 +20,7 @@ void map(const datastore::Collection &from, gk::v1::Collection *to);
 void map(const datastore::Identity &from, gk::v1::Identity *to);
 void map(const datastore::Identities &from, gk::v1::LookupIdentitiesResponse *to);
 void map(const datastore::Policies &from, gk::v1::CheckAccessResponse *to);
+void map(const datastore::Policies &from, gk::v1::CheckRbacResponse *to);
 void map(const datastore::RbacPolicy &from, gk::v1::RbacPolicy *to);
-void map(const datastore::RbacPolicies &from, gk::v1::CheckRbacResponse *to);
 void map(const datastore::Role &from, gk::v1::Role *to);
 } // namespace service

--- a/src/service/mappers.h
+++ b/src/service/mappers.h
@@ -16,10 +16,10 @@ datastore::Role         map(const gk::v1::CreateRoleRequest *from);
 
 void map(const datastore::AccessPolicy &from, gk::v1::AccessPolicy *to);
 void map(const datastore::AccessPolicy &from, gk::v1::Policy *to);
-void map(const datastore::AccessPolicies &from, gk::v1::CheckAccessResponse *to);
 void map(const datastore::Collection &from, gk::v1::Collection *to);
 void map(const datastore::Identity &from, gk::v1::Identity *to);
 void map(const datastore::Identities &from, gk::v1::LookupIdentitiesResponse *to);
+void map(const datastore::Policies &from, gk::v1::CheckAccessResponse *to);
 void map(const datastore::RbacPolicy &from, gk::v1::RbacPolicy *to);
 void map(const datastore::RbacPolicies &from, gk::v1::CheckRbacResponse *to);
 void map(const datastore::Role &from, gk::v1::Role *to);


### PR DESCRIPTION
Implement gRPC endpoint to consume rebuild cache events and re-create or update redis entries for _Access_ and _RBAC_ policies.