### PR TITLE
Drop principals type

### DIFF
--- a/proto/gk/v1/gatekeeper.proto
+++ b/proto/gk/v1/gatekeeper.proto
@@ -150,12 +150,6 @@ service Gatekeeper {
 	}
 }
 
-enum PrincipalType {
-	PRINCIPAL_TYPE_UNSPECIFIED = 0;
-	PRINCIPAL_TYPE_COLLECTION  = 1;
-	PRINCIPAL_TYPE_IDENTITY    = 2;
-}
-
 message Meta {
 	optional Page page = 1;
 }
@@ -170,18 +164,14 @@ message Policy {
 	string                 id    = 1;
 }
 
-message Principal {
-	PrincipalType type = 1;
-	string        id   = 2;
-}
-
 // Access policies
 message AccessPolicy {
 	string          id   = 1;
 	optional string name = 2;
 
-	repeated Principal        principals = 3;
-	repeated AccessPolicyRule rules      = 4;
+	repeated string           collection_ids = 3;
+	repeated string           identity_ids   = 4;
+	repeated AccessPolicyRule rules          = 5;
 }
 
 message AccessPolicyRule {
@@ -206,8 +196,9 @@ message CreateAccessPolicyRequest {
 	optional string id   = 1;
 	optional string name = 2;
 
-	repeated Principal        principals = 3;
-	repeated AccessPolicyRule rules      = 4;
+	repeated string           collection_ids = 3;
+	repeated string           identity_ids   = 4;
+	repeated AccessPolicyRule rules          = 5;
 }
 
 // Collections
@@ -317,8 +308,9 @@ message RbacPolicy {
 	string          id   = 1;
 	optional string name = 2;
 
-	repeated Principal      principals = 3;
-	repeated RbacPolicyRule rules      = 4;
+	repeated string         collection_ids = 3;
+	repeated string         identity_ids   = 4;
+	repeated RbacPolicyRule rules          = 5;
 }
 
 message RbacPolicyRule {
@@ -343,8 +335,9 @@ message CreateRbacPolicyRequest {
 	optional string id   = 1;
 	optional string name = 2;
 
-	repeated Principal      principals = 3;
-	repeated RbacPolicyRule rules      = 4;
+	repeated string         collection_ids = 3;
+	repeated string         identity_ids   = 4;
+	repeated RbacPolicyRule rules          = 5;
 }
 
 // Roles

--- a/src/datastore/rbac-policies.h
+++ b/src/datastore/rbac-policies.h
@@ -52,15 +52,7 @@ public:
 		bool operator==(const Data &) const noexcept = default;
 	};
 
-	struct Principal {
-		std::string id;
-		enum class Type { Unspecified, Collection, Identity } type;
-
-		bool operator==(const Principal &) const noexcept = default;
-	};
-
-	using Rules      = std::vector<Rule>;
-	using Principals = std::vector<Principal>;
+	using Rules = std::vector<Rule>;
 
 	RbacPolicy(const Data &data) noexcept;
 	RbacPolicy(Data &&data) noexcept;
@@ -70,16 +62,15 @@ public:
 	const std::string &id() const noexcept { return _data.id; }
 	const int         &rev() const noexcept { return _rev; }
 
+	const collections_t collections() const;
+	void                addCollection(const collection_t &id) const;
+
 	const identities_t identities(bool expand = false) const;
 	void               addIdentity(const identity_t &id) const;
 
 	const Data::name_t &name() const noexcept { return _data.name; }
 	void                name(const std::string &name) noexcept { _data.name = name; }
 	void                name(std::string &&name) noexcept { _data.name = std::move(name); }
-
-	const Principals principals() const;
-	void             addPrincipal(const Principal principal) const;
-	void             addCollection(const collection_t &id) const;
 
 	const Rules rules() const;
 	void        addRule(const Rule &rule) const;

--- a/src/service/mappers.cpp
+++ b/src/service/mappers.cpp
@@ -132,7 +132,7 @@ void map(const datastore::RbacPolicy &from, gk::v1::RbacPolicy *to) {
 		to->set_name(*from.name());
 	}
 
-	// Set role ids from DB table
+	// Map role ids
 	auto rules = from.rules();
 	if (rules.size() > 0) {
 		for (const auto &rule : rules) {
@@ -141,14 +141,13 @@ void map(const datastore::RbacPolicy &from, gk::v1::RbacPolicy *to) {
 		}
 	}
 
-	// Set principals ids from DB table
-	auto principals = from.principals();
-	if (principals.size() > 0) {
-		for (const auto &principal : principals) {
-			auto p = to->add_principals();
-			p->set_id(principal.id);
-			p->set_type(static_cast<gk::v1::PrincipalType>(principal.type));
-		}
+	// Map principals
+	for (const auto &id : from.collections()) {
+		to->add_collection_ids(id);
+	}
+
+	for (const auto &id : from.identities()) {
+		to->add_identity_ids(id);
 	}
 }
 


### PR DESCRIPTION
Using principals instead of collections and identities adds more complexity to the gRPC endpoints and doesn't give a significant advantage.