### PR TITLE
Drop lookup identities

### DIFF
--- a/proto/gk/v1/gatekeeper.proto
+++ b/proto/gk/v1/gatekeeper.proto
@@ -88,12 +88,6 @@ service Gatekeeper {
 		};
 	}
 
-	rpc LookupIdentities(LookupIdentitiesRequest) returns (LookupIdentitiesResponse) {
-		option (google.api.http) = {
-			get : "/v1/identities"
-		};
-	}
-
 	rpc RetrieveIdentity(RetrieveIdentityRequest) returns (Identity) {
 		option (google.api.http) = {
 			get : "/v1/identities/{id}"
@@ -283,17 +277,11 @@ message CreateIdentityRequest {
 	optional google.protobuf.Struct attrs = 3;
 }
 
-message LookupIdentitiesRequest {
-	optional string sub = 1;
-}
-
-message LookupIdentitiesResponse {
-	repeated Identity data = 1;
-	Meta              meta = 2;
-}
-
 message RetrieveIdentityRequest {
-	string id = 1;
+	oneof identity {
+		string id  = 1;
+		string sub = 2;
+	}
 }
 
 message UpdateIdentityRequest {

--- a/src/datastore/identities.cpp
+++ b/src/datastore/identities.cpp
@@ -81,28 +81,6 @@ void Identity::store() const {
 	_rev = res.at(0, 0).as<int>();
 }
 
-Identities LookupIdentities(const std::string &sub) {
-	std::string_view qry = R"(
-		select
-			_id,
-			_rev,
-			sub,
-			attrs
-		from identities
-		where
-			sub = $1::text;
-	)";
-
-	auto res = pg::exec(qry, sub);
-
-	Identities identities;
-	for (const auto &row : res) {
-		identities.push_back(Identity(row));
-	}
-
-	return identities;
-}
-
 Identity RetrieveIdentity(const std::string &id) {
 	std::string_view qry = R"(
 		select
@@ -116,6 +94,26 @@ Identity RetrieveIdentity(const std::string &id) {
 	)";
 
 	auto res = pg::exec(qry, id);
+	if (res.empty()) {
+		throw err::DatastoreIdentityNotFound();
+	}
+
+	return Identity(res[0]);
+}
+
+Identity RetrieveIdentityBySub(const std::string &sub) {
+	std::string_view qry = R"(
+		select
+			_id,
+			_rev,
+			sub,
+			attrs
+		from identities
+		where
+			sub = $1::text;
+	)";
+
+	auto res = pg::exec(qry, sub);
 	if (res.empty()) {
 		throw err::DatastoreIdentityNotFound();
 	}

--- a/src/datastore/identities.h
+++ b/src/datastore/identities.h
@@ -46,6 +46,6 @@ private:
 
 using Identities = std::vector<Identity>;
 
-Identities LookupIdentities(const std::string &sub);
-Identity   RetrieveIdentity(const std::string &id);
+Identity RetrieveIdentity(const std::string &id);
+Identity RetrieveIdentityBySub(const std::string &sub);
 } // namespace datastore

--- a/src/service/grpc.cpp
+++ b/src/service/grpc.cpp
@@ -346,8 +346,13 @@ grpc::ServerUnaryReactor *Grpc::RetrieveIdentity(
 	auto *reactor = context->DefaultReactor();
 
 	try {
-		auto identity = datastore::RetrieveIdentity(request->id());
-		map(identity, response);
+		if (request->has_sub()) {
+			auto identity = datastore::RetrieveIdentityBySub(request->sub());
+			map(identity, response);
+		} else {
+			auto identity = datastore::RetrieveIdentity(request->id());
+			map(identity, response);
+		}
 	} catch (const err::DatastoreIdentityNotFound &) {
 		reactor->Finish(grpc::Status(grpc::StatusCode::NOT_FOUND, "Document not found"));
 		return reactor;
@@ -356,18 +361,6 @@ grpc::ServerUnaryReactor *Grpc::RetrieveIdentity(
 		return reactor;
 	}
 
-	reactor->Finish(grpc::Status::OK);
-	return reactor;
-}
-
-grpc::ServerUnaryReactor *Grpc::LookupIdentities(
-	grpc::CallbackServerContext *context, const gk::v1::LookupIdentitiesRequest *request,
-	gk::v1::LookupIdentitiesResponse *response) {
-	auto *reactor = context->DefaultReactor();
-
-	const auto identities = datastore::LookupIdentities(request->sub());
-
-	map(identities, response);
 	reactor->Finish(grpc::Status::OK);
 	return reactor;
 }

--- a/src/service/grpc.h
+++ b/src/service/grpc.h
@@ -58,10 +58,6 @@ public:
 		grpc::CallbackServerContext *context, const gk::v1::RetrieveIdentityRequest *request,
 		gk::v1::Identity *response) override;
 
-	grpc::ServerUnaryReactor *LookupIdentities(
-		grpc::CallbackServerContext *context, const gk::v1::LookupIdentitiesRequest *request,
-		gk::v1::LookupIdentitiesResponse *response) override;
-
 	grpc::ServerUnaryReactor *UpdateIdentity(
 		grpc::CallbackServerContext *context, const gk::v1::UpdateIdentityRequest *request,
 		gk::v1::Identity *response) override;

--- a/src/service/grpc_test.cpp
+++ b/src/service/grpc_test.cpp
@@ -834,9 +834,11 @@ TEST_F(GrpcTest, RetrieveIdentity) {
 
 	// Success: retrieve identity by id
 	{
-		const datastore::Identity identity(
-			{.id = "id:GrpcTest.RetrieveIdentity", .sub = "sub:GrpcTest.RetrieveIdentity"});
-		EXPECT_NO_THROW(identity.store());
+		const datastore::Identity identity({
+			.id  = "id:GrpcTest.RetrieveIdentity",
+			.sub = "sub:GrpcTest.RetrieveIdentity",
+		});
+		ASSERT_NO_THROW(identity.store());
 
 		grpc::CallbackServerContext           ctx;
 		grpc::testing::DefaultReactorTestPeer peer(&ctx);
@@ -913,7 +915,7 @@ TEST_F(GrpcTest, RetrieveIdentity) {
 		gk::v1::Identity                      response;
 
 		gk::v1::RetrieveIdentityRequest request;
-		request.set_id("id:GrpcTest.RetrieveIdentity-not-found");
+		request.set_id("id:GrpcTest.RetrieveIdentity-not_found");
 
 		auto reactor = service.RetrieveIdentity(&ctx, &request, &response);
 		EXPECT_TRUE(peer.test_status_set());

--- a/src/service/mappers.cpp
+++ b/src/service/mappers.cpp
@@ -105,13 +105,6 @@ void map(const datastore::Identity &from, gk::v1::Identity *to) {
 	}
 }
 
-void map(const datastore::Identities &from, gk::v1::LookupIdentitiesResponse *to) {
-	for (const auto &identity : from) {
-		auto i = to->add_data();
-		map(identity, i);
-	}
-}
-
 void map(const datastore::Policies &from, gk::v1::CheckAccessResponse *to) {
 	for (const auto &policy : from) {
 		auto p = to->add_policies();

--- a/src/service/mappers.h
+++ b/src/service/mappers.h
@@ -18,7 +18,6 @@ void map(const datastore::AccessPolicy &from, gk::v1::AccessPolicy *to);
 void map(const datastore::AccessPolicy &from, gk::v1::Policy *to);
 void map(const datastore::Collection &from, gk::v1::Collection *to);
 void map(const datastore::Identity &from, gk::v1::Identity *to);
-void map(const datastore::Identities &from, gk::v1::LookupIdentitiesResponse *to);
 void map(const datastore::Policies &from, gk::v1::CheckAccessResponse *to);
 void map(const datastore::Policies &from, gk::v1::CheckRbacResponse *to);
 void map(const datastore::RbacPolicy &from, gk::v1::RbacPolicy *to);


### PR DESCRIPTION
`LookupIdentities` gRPC endpoint is a bit odd since it attempts to retrieve an identity by `sub` and the response (`LookupIdentitiesResponse`) returns a list of identities which will have either `0` entries (if there are no matches) or `1` entry if there is a match. Since `sub` must be unique across identities there can't be more than 1 result. 

This change is to drop the `LookupIdentities` gRPC endpoint and update `RetrieveIdentity` endpoint to allow retrieving identities by `sub`. 